### PR TITLE
✨ [Feat]: 사용자 추출 어노테이션 구현, CORS 설정, Swagger 설정 수정

### DIFF
--- a/src/main/java/com/avab/avab/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/avab/avab/apiPayload/code/status/ErrorStatus.java
@@ -24,7 +24,10 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "토큰이 만료되었습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 유효하지 않습니다."),
     INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_003", "올바른 이메일이나 패스워드가 아닙니다."),
-    AUTH_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_004", "없는 유저 입니다.");
+
+    // User 관련
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_004", "존재하지 않는 사용자입니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/avab/avab/apiPayload/exception/AuthException.java
+++ b/src/main/java/com/avab/avab/apiPayload/exception/AuthException.java
@@ -1,7 +1,6 @@
-package com.avab.avab.apiPayload.exception.auth;
+package com.avab.avab.apiPayload.exception;
 
 import com.avab.avab.apiPayload.code.BaseErrorCode;
-import com.avab.avab.apiPayload.exception.GeneralException;
 
 public class AuthException extends GeneralException {
 

--- a/src/main/java/com/avab/avab/apiPayload/exception/S3Exception.java
+++ b/src/main/java/com/avab/avab/apiPayload/exception/S3Exception.java
@@ -1,9 +1,9 @@
-package com.avab.avab.apiPayload.exception.S3;
+package com.avab.avab.apiPayload.exception;
 
 import com.avab.avab.apiPayload.code.BaseErrorCode;
-import com.avab.avab.apiPayload.exception.GeneralException;
 
 public class S3Exception extends GeneralException {
+
     public S3Exception(BaseErrorCode code) {
         super(code);
     }

--- a/src/main/java/com/avab/avab/apiPayload/exception/UserException.java
+++ b/src/main/java/com/avab/avab/apiPayload/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.avab.avab.apiPayload.exception;
+
+import com.avab.avab.apiPayload.code.BaseErrorCode;
+
+public class UserException extends GeneralException {
+
+    public UserException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/avab/avab/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/avab/avab/aws/s3/AmazonS3Manager.java
@@ -11,7 +11,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
-import com.avab.avab.apiPayload.exception.S3.S3Exception;
+import com.avab.avab.apiPayload.exception.S3Exception;
 import com.avab.avab.config.AmazonConfig;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/avab/avab/config/SecurityConfig.java
+++ b/src/main/java/com/avab/avab/config/SecurityConfig.java
@@ -12,7 +12,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.avab.avab.auth.filter.JwtRequestFilter;
+import com.avab.avab.security.filter.JwtRequestFilter;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/avab/avab/config/SwaggerConfig.java
+++ b/src/main/java/com/avab/avab/config/SwaggerConfig.java
@@ -6,19 +6,35 @@ import org.springframework.context.annotation.Configuration;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class SwaggerConfig {
+
     @Bean
     public OpenAPI avabAPI() {
         Info info = new Info().title("AvAb API").description("AvAb API 명세").version("0.0.1");
 
-        Components components = new Components();
+        String jwtSchemeName = "JWT TOKEN";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components =
+                new Components()
+                        .addSecuritySchemes(
+                                jwtSchemeName,
+                                new SecurityScheme()
+                                        .name(jwtSchemeName)
+                                        .type(Type.HTTP)
+                                        .scheme("Bearer")
+                                        .bearerFormat("JWT"));
 
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))
                 .info(info)
+                .addSecurityItem(securityRequirement)
                 .components(components);
     }
 }

--- a/src/main/java/com/avab/avab/config/WebConfig.java
+++ b/src/main/java/com/avab/avab/config/WebConfig.java
@@ -1,0 +1,34 @@
+package com.avab.avab.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.avab.avab.security.handler.resolver.AuthUserArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(false)
+                .maxAge(6000);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -11,8 +11,8 @@ import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListD
 import com.avab.avab.service.RecreationService;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -24,9 +24,7 @@ public class RecreationController {
 
     @Operation(summary = "인기 레크레이션 목록 조회 API", description = "조회수를 기준으로 인기 레크레이션 목록을 조회합니다.")
     @ApiResponses({
-        @ApiResponse(
-                responseCode = "COMMON200",
-                description = "OK, 성공"),
+        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     @GetMapping("/popular")
     public BaseResponse<List<PopularRecreationListDTO>> getTop3RecreationsByViewCount() {

--- a/src/main/java/com/avab/avab/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/avab/avab/security/filter/JwtRequestFilter.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.filter;
+package com.avab.avab.security.filter;
 
 import java.io.IOException;
 
@@ -15,8 +15,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
 import com.avab.avab.apiPayload.exception.auth.AuthException;
-import com.avab.avab.auth.jwt.JwtTokenProvider;
-import com.avab.avab.auth.principal.PrincipalDetailsService;
+import com.avab.avab.security.provider.JwtTokenProvider;
+import com.avab.avab.security.principal.PrincipalDetailsService;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/avab/avab/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/avab/avab/security/filter/JwtRequestFilter.java
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
-import com.avab.avab.apiPayload.exception.auth.AuthException;
-import com.avab.avab.security.provider.JwtTokenProvider;
+import com.avab.avab.apiPayload.exception.AuthException;
 import com.avab.avab.security.principal.PrincipalDetailsService;
+import com.avab.avab.security.provider.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;
 
@@ -49,7 +49,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext()
                             .setAuthentication(usernamePasswordAuthenticationToken);
                 } else {
-                    throw new AuthException(ErrorStatus.AUTH_USER_NOT_FOUND);
+                    throw new AuthException(ErrorStatus.USER_NOT_FOUND);
                 }
             } else {
                 throw new AuthException(ErrorStatus.AUTH_INVALID_TOKEN);

--- a/src/main/java/com/avab/avab/security/handler/annotation/AuthUser.java
+++ b/src/main/java/com/avab/avab/security/handler/annotation/AuthUser.java
@@ -1,0 +1,10 @@
+package com.avab.avab.security.handler.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface AuthUser {}

--- a/src/main/java/com/avab/avab/security/handler/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/avab/avab/security/handler/resolver/AuthUserArgumentResolver.java
@@ -1,0 +1,59 @@
+package com.avab.avab.security.handler.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.avab.avab.apiPayload.code.status.ErrorStatus;
+import com.avab.avab.apiPayload.exception.GeneralException;
+import com.avab.avab.domain.User;
+import com.avab.avab.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory)
+            throws Exception {
+        System.out.println("hihi");
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Object principal = null;
+        if (authentication != null) {
+            // 로그인하지 않은 익명 사용자라면 null 반환
+            if (authentication.getName().equals("anonymousUser")) {
+                return null;
+            }
+            principal = authentication.getPrincipal();
+        }
+        if (principal == null || principal.getClass() == String.class) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                (UsernamePasswordAuthenticationToken) authentication;
+        Long userId = Long.valueOf(authenticationToken.getName());
+
+        return userService.findUserById(userId);
+    }
+}

--- a/src/main/java/com/avab/avab/security/principal/PrincipalDetails.java
+++ b/src/main/java/com/avab/avab/security/principal/PrincipalDetails.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.principal;
+package com.avab.avab.security.principal;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/com/avab/avab/security/principal/PrincipalDetails.java
+++ b/src/main/java/com/avab/avab/security/principal/PrincipalDetails.java
@@ -33,7 +33,7 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getUsername();
+        return user.getId().toString();
     }
 
     public String getEmail() {

--- a/src/main/java/com/avab/avab/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/avab/avab/security/principal/PrincipalDetailsService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
-import com.avab.avab.apiPayload.exception.auth.AuthException;
+import com.avab.avab.apiPayload.exception.AuthException;
 import com.avab.avab.domain.User;
 import com.avab.avab.repository.UserRepository;
 
@@ -25,7 +25,7 @@ public class PrincipalDetailsService implements UserDetailsService {
         User user =
                 userRepository
                         .findById(Long.parseLong(userId))
-                        .orElseThrow(() -> new AuthException(ErrorStatus.AUTH_USER_NOT_FOUND));
+                        .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND));
 
         return new PrincipalDetails(user);
     }

--- a/src/main/java/com/avab/avab/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/avab/avab/security/principal/PrincipalDetailsService.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.principal;
+package com.avab.avab.security.principal;
 
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/avab/avab/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/avab/avab/security/provider/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.jwt;
+package com.avab.avab.security.provider;
 
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;

--- a/src/main/java/com/avab/avab/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/avab/avab/security/provider/JwtTokenProvider.java
@@ -10,9 +10,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
-import com.avab.avab.apiPayload.exception.auth.AuthException;
+import com.avab.avab.apiPayload.exception.AuthException;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 
 @Component

--- a/src/main/java/com/avab/avab/security/test/AuthController.java
+++ b/src/main/java/com/avab/avab/security/test/AuthController.java
@@ -1,11 +1,11 @@
 package com.avab.avab.security.test;
 
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.avab.avab.apiPayload.BaseResponse;
-import com.avab.avab.auth.test.dto.LoginRequest;
-import com.avab.avab.auth.test.dto.LoginResponse;
-import com.avab.avab.apiPayload.ApiResponse;
 import com.avab.avab.security.test.dto.LoginRequest;
 import com.avab.avab.security.test.dto.LoginResponse;
 

--- a/src/main/java/com/avab/avab/security/test/AuthController.java
+++ b/src/main/java/com/avab/avab/security/test/AuthController.java
@@ -1,10 +1,10 @@
-package com.avab.avab.auth.test;
+package com.avab.avab.security.test;
 
 import org.springframework.web.bind.annotation.*;
 
 import com.avab.avab.apiPayload.ApiResponse;
-import com.avab.avab.auth.test.dto.LoginRequest;
-import com.avab.avab.auth.test.dto.LoginResponse;
+import com.avab.avab.security.test.dto.LoginRequest;
+import com.avab.avab.security.test.dto.LoginResponse;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/avab/avab/security/test/AuthService.java
+++ b/src/main/java/com/avab/avab/security/test/AuthService.java
@@ -1,10 +1,10 @@
-package com.avab.avab.auth.test;
+package com.avab.avab.security.test;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.avab.avab.auth.jwt.JwtTokenProvider;
-import com.avab.avab.auth.test.dto.LoginResponse;
+import com.avab.avab.security.provider.JwtTokenProvider;
+import com.avab.avab.security.test.dto.LoginResponse;
 import com.avab.avab.domain.User;
 import com.avab.avab.repository.UserRepository;
 

--- a/src/main/java/com/avab/avab/security/test/AuthService.java
+++ b/src/main/java/com/avab/avab/security/test/AuthService.java
@@ -3,10 +3,10 @@ package com.avab.avab.security.test;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.avab.avab.security.provider.JwtTokenProvider;
-import com.avab.avab.security.test.dto.LoginResponse;
 import com.avab.avab.domain.User;
 import com.avab.avab.repository.UserRepository;
+import com.avab.avab.security.provider.JwtTokenProvider;
+import com.avab.avab.security.test.dto.LoginResponse;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/avab/avab/security/test/dto/LoginRequest.java
+++ b/src/main/java/com/avab/avab/security/test/dto/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.test.dto;
+package com.avab.avab.security.test.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/avab/avab/security/test/dto/LoginResponse.java
+++ b/src/main/java/com/avab/avab/security/test/dto/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.test.dto;
+package com.avab.avab.security.test.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/avab/avab/service/UserService.java
+++ b/src/main/java/com/avab/avab/service/UserService.java
@@ -1,0 +1,8 @@
+package com.avab.avab.service;
+
+import com.avab.avab.domain.User;
+
+public interface UserService {
+
+    User findUserById(Long userId);
+}

--- a/src/main/java/com/avab/avab/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/UserServiceImpl.java
@@ -1,0 +1,27 @@
+package com.avab.avab.service.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.avab.avab.apiPayload.code.status.ErrorStatus;
+import com.avab.avab.apiPayload.exception.UserException;
+import com.avab.avab.domain.User;
+import com.avab.avab.repository.UserRepository;
+import com.avab.avab.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public User findUserById(Long userId) {
+        return userRepository
+                .findById(userId)
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #23 

## 📌 개요
- 일부 파일 디렉토리 및 이름 수정
- 유저 추출 어노테이션 추가
- CORS 추가
- Swagger 시큐리티 설정 추가

## 🔁 변경 사항
- 일부 파일 디렉토리 및 이름 수정
0b84796f1d0199dddb37086df89894f3cd4c7fbf
dd0a0d8b0cf9ac0280be332fc0e989ab1d4429f6
705b9451a894c09c71a7cfef324bd1a94a935deb
2cbf92d9f54ac4b26a044d2ab593fa7ca75668e5

- **유저 추출 어노테이션 추가 << 중요 🔥**
유저 추출 어노테이션 `AuthUser`를 추가했습니다.
이제 따로 서비스에서 User를 찾을 필요 없이 Controller에서 파라미터로 받아오시면 됩니다.
이 때 반드시 Swagger 어노테이션을 이용해 해당 파라미터를 숨겨야 합니다. (숨기지 않으면 문서에서 굉장히 이상하게 표시됨)
  ```java
  @Parameter(name = "user", hidden = true)
  public String test(@AuthUser User user) {
  ...
  }
  ```
  이 때, 사용자가 로그인 했다면 적절한 유저 객체가 들어가고,
  로그인하지 않으면 `null`이 됩니다.
  동일한 API지만 로그인 여부에 따라 응답을 달리 해야할 경우가 필요할 듯 하여 이렇게 구성하였습니다.
  추후 이러한 API 구현할 때 서비스 레이어에서 `null` 여부 체크해주시면 됩니다.
- CORS 추가
argument resolver 추가하는 김에 같이 설정했습니다.
설정 클래스는 `WebConfig`입니다.
- Swagger 시큐리티 설정 추가
API 문서에서 바로 Authorization 헤더를 추가할 수 있도록 설정 클래슬를 수정했습니다.
이제 문서 페이지에서 상단 Authorize를 누르고 토큰을 넣어주시면 인증이 필요한 APi에 접근할 수 있습니다.

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
현재 코드 컨벤션 적용이 잘 되고 있지 않는 현상이 발생하고 있습니다.
서버를 시작해야(정확히는 빌드할 때) 코드 포맷팅이 되는 관계로, **반드시 커밋하기 전 서버를 한 번 시작해주세요**

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
