### PR TITLE
:sparkles: [Feat] 레크레이션 상세설명 API, 레크레이션 존재 검증 어노테이션 구현

### DIFF
--- a/src/main/java/com/avab/avab/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/avab/avab/apiPayload/code/status/ErrorStatus.java
@@ -26,7 +26,10 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_003", "올바른 이메일이나 패스워드가 아닙니다."),
 
     // User 관련
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_004", "존재하지 않는 사용자입니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_004", "존재하지 않는 사용자입니다."),
+
+    // Recreation 관련
+    RECREATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RECREATION_400", "존재하지 않는 레크레이션입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/avab/avab/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/avab/avab/apiPayload/code/status/ErrorStatus.java
@@ -24,7 +24,10 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "토큰이 만료되었습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 유효하지 않습니다."),
     INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_003", "올바른 이메일이나 패스워드가 아닙니다."),
-    AUTH_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_004", "없는 유저 입니다.");
+
+    // User 관련
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_004", "존재하지 않는 사용자입니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/avab/avab/apiPayload/exception/AuthException.java
+++ b/src/main/java/com/avab/avab/apiPayload/exception/AuthException.java
@@ -1,7 +1,6 @@
-package com.avab.avab.apiPayload.exception.auth;
+package com.avab.avab.apiPayload.exception;
 
 import com.avab.avab.apiPayload.code.BaseErrorCode;
-import com.avab.avab.apiPayload.exception.GeneralException;
 
 public class AuthException extends GeneralException {
 

--- a/src/main/java/com/avab/avab/apiPayload/exception/S3Exception.java
+++ b/src/main/java/com/avab/avab/apiPayload/exception/S3Exception.java
@@ -1,9 +1,9 @@
-package com.avab.avab.apiPayload.exception.S3;
+package com.avab.avab.apiPayload.exception;
 
 import com.avab.avab.apiPayload.code.BaseErrorCode;
-import com.avab.avab.apiPayload.exception.GeneralException;
 
 public class S3Exception extends GeneralException {
+
     public S3Exception(BaseErrorCode code) {
         super(code);
     }

--- a/src/main/java/com/avab/avab/apiPayload/exception/UserException.java
+++ b/src/main/java/com/avab/avab/apiPayload/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.avab.avab.apiPayload.exception;
+
+import com.avab.avab.apiPayload.code.BaseErrorCode;
+
+public class UserException extends GeneralException {
+
+    public UserException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/avab/avab/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/avab/avab/aws/s3/AmazonS3Manager.java
@@ -11,7 +11,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
-import com.avab.avab.apiPayload.exception.S3.S3Exception;
+import com.avab.avab.apiPayload.exception.S3Exception;
 import com.avab.avab.config.AmazonConfig;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/avab/avab/config/SecurityConfig.java
+++ b/src/main/java/com/avab/avab/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
         "/swagger-resources/**",
         "/v3/api-docs/**",
         "/api/recreations/popular",
-        "/api/recreations/description/*"
+        "/api/recreations/{recreationId}/description"
     };
 
     @Bean

--- a/src/main/java/com/avab/avab/config/SecurityConfig.java
+++ b/src/main/java/com/avab/avab/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
         "/swagger-resources/**",
         "/v3/api-docs/**",
         "/api/recreations/popular",
-        "/api/recreations/{recreationId}/description"
+        "/api/recreations/{recreationId}"
     };
 
     @Bean

--- a/src/main/java/com/avab/avab/config/SecurityConfig.java
+++ b/src/main/java/com/avab/avab/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
         "/swagger-ui/**",
         "/swagger-resources/**",
         "/v3/api-docs/**",
-        "/api/recreations/popular"
+        "/api/recreations/popular",
+        "/api/recreations/description/*"
     };
 
     @Bean

--- a/src/main/java/com/avab/avab/config/SecurityConfig.java
+++ b/src/main/java/com/avab/avab/config/SecurityConfig.java
@@ -12,7 +12,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.avab.avab.auth.filter.JwtRequestFilter;
+import com.avab.avab.security.filter.JwtRequestFilter;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/avab/avab/config/SwaggerConfig.java
+++ b/src/main/java/com/avab/avab/config/SwaggerConfig.java
@@ -6,19 +6,35 @@ import org.springframework.context.annotation.Configuration;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class SwaggerConfig {
+
     @Bean
     public OpenAPI avabAPI() {
         Info info = new Info().title("AvAb API").description("AvAb API 명세").version("0.0.1");
 
-        Components components = new Components();
+        String jwtSchemeName = "JWT TOKEN";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components =
+                new Components()
+                        .addSecuritySchemes(
+                                jwtSchemeName,
+                                new SecurityScheme()
+                                        .name(jwtSchemeName)
+                                        .type(Type.HTTP)
+                                        .scheme("Bearer")
+                                        .bearerFormat("JWT"));
 
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))
                 .info(info)
+                .addSecurityItem(securityRequirement)
                 .components(components);
     }
 }

--- a/src/main/java/com/avab/avab/config/WebConfig.java
+++ b/src/main/java/com/avab/avab/config/WebConfig.java
@@ -1,0 +1,34 @@
+package com.avab.avab.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.avab.avab.security.handler.resolver.AuthUserArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(false)
+                .maxAge(6000);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -2,11 +2,10 @@ package com.avab.avab.controller;
 
 import java.util.List;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.avab.avab.apiPayload.BaseResponse;
+import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
 import com.avab.avab.service.RecreationService;
 
@@ -29,5 +28,15 @@ public class RecreationController {
     @GetMapping("/popular")
     public BaseResponse<List<PopularRecreationListDTO>> getTop3RecreationsByViewCount() {
         return BaseResponse.onSuccess(recreationService.getTop3RecreationsByViewCount());
+    }
+
+    @Operation(summary = "레크레이션 상세설명 조회 API", description = "레크레이션 상세설명을 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @GetMapping("/description/{recreationId}")
+    public BaseResponse<DescriptionDTO> getRecreationDescription(
+            @PathVariable(name = "recreationId") Long recreationId) {
+        return BaseResponse.onSuccess(recreationService.getRecreationDescription(recreationId));
     }
 }

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -26,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/recreations")
 @RequiredArgsConstructor
 public class RecreationController {
-
     private final RecreationService recreationService;
 
     @Operation(summary = "인기 레크레이션 목록 조회 API", description = "조회수를 기준으로 인기 레크레이션 목록을 조회합니다.")

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.avab.avab.apiPayload.BaseResponse;
+import com.avab.avab.converter.RecreationConverter;
+import com.avab.avab.domain.Recreation;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
 import com.avab.avab.service.RecreationService;
@@ -40,6 +42,7 @@ public class RecreationController {
     @GetMapping("/{recreationId}")
     public BaseResponse<DescriptionDTO> getRecreationDescription(
             @PathVariable(name = "recreationId") Long recreationId) {
-        return BaseResponse.onSuccess(recreationService.getRecreationDescription(recreationId));
+        Recreation recreation = recreationService.getRecreationDescription(recreationId);
+        return BaseResponse.onSuccess(RecreationConverter.toDescriptionDTO(recreation));
     }
 }

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -10,20 +10,21 @@ import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListD
 import com.avab.avab.service.RecreationService;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/recreations")
 @RequiredArgsConstructor
 public class RecreationController {
-
     private final RecreationService recreationService;
 
     @Operation(summary = "인기 레크레이션 목록 조회 API", description = "조회수를 기준으로 인기 레크레이션 목록을 조회합니다.")
     @ApiResponses({
-        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @ApiResponse(
+                    responseCode = "COMMON200",
+                    description = "OK, 성공"),
     })
     @GetMapping("/popular")
     public BaseResponse<List<PopularRecreationListDTO>> getTop3RecreationsByViewCount() {

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -13,8 +13,8 @@ import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListD
 import com.avab.avab.service.RecreationService;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -26,9 +26,7 @@ public class RecreationController {
 
     @Operation(summary = "인기 레크레이션 목록 조회 API", description = "조회수를 기준으로 인기 레크레이션 목록을 조회합니다.")
     @ApiResponses({
-        @ApiResponse(
-                responseCode = "COMMON200",
-                description = "OK, 성공"),
+        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     @GetMapping("/popular")
     public BaseResponse<List<PopularRecreationListDTO>> getTop3RecreationsByViewCount() {
@@ -39,7 +37,7 @@ public class RecreationController {
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
-    @GetMapping("/description/{recreationId}")
+    @GetMapping("/{recreationId}/description")
     public BaseResponse<DescriptionDTO> getRecreationDescription(
             @PathVariable(name = "recreationId") Long recreationId) {
         return BaseResponse.onSuccess(recreationService.getRecreationDescription(recreationId));

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -11,8 +11,8 @@ import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListD
 import com.avab.avab.service.RecreationService;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -24,9 +24,7 @@ public class RecreationController {
 
     @Operation(summary = "인기 레크레이션 목록 조회 API", description = "조회수를 기준으로 인기 레크레이션 목록을 조회합니다.")
     @ApiResponses({
-        @ApiResponse(
-                responseCode = "COMMON200",
-                description = "OK, 성공"),
+        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     @GetMapping("/popular")
     public BaseResponse<List<PopularRecreationListDTO>> getTop3RecreationsByViewCount() {

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -13,8 +13,8 @@ import com.avab.avab.converter.RecreationConverter;
 import com.avab.avab.domain.Recreation;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
-import com.avab.avab.security.handler.annotation.ExistRecreations;
 import com.avab.avab.service.RecreationService;
+import com.avab.avab.validation.annotation.ExistRecreation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -43,7 +43,7 @@ public class RecreationController {
     })
     @GetMapping("/{recreationId}")
     public BaseResponse<DescriptionDTO> getRecreationDescription(
-            @ExistRecreations @PathVariable(name = "recreationId") Long recreationId) {
+            @ExistRecreation @PathVariable(name = "recreationId") Long recreationId) {
         Recreation recreation = recreationService.getRecreationDescription(recreationId);
         return BaseResponse.onSuccess(RecreationConverter.toDescriptionDTO(recreation));
     }

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -2,7 +2,10 @@ package com.avab.avab.controller;
 
 import java.util.List;
 
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.avab.avab.apiPayload.BaseResponse;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
@@ -18,13 +21,14 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/recreations")
 @RequiredArgsConstructor
 public class RecreationController {
+
     private final RecreationService recreationService;
 
     @Operation(summary = "인기 레크레이션 목록 조회 API", description = "조회수를 기준으로 인기 레크레이션 목록을 조회합니다.")
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "COMMON200",
-                    description = "OK, 성공"),
+        @ApiResponse(
+                responseCode = "COMMON200",
+                description = "OK, 성공"),
     })
     @GetMapping("/popular")
     public BaseResponse<List<PopularRecreationListDTO>> getTop3RecreationsByViewCount() {

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -2,6 +2,7 @@ package com.avab.avab.controller;
 
 import java.util.List;
 
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import com.avab.avab.converter.RecreationConverter;
 import com.avab.avab.domain.Recreation;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
+import com.avab.avab.security.handler.annotation.ExistRecreations;
 import com.avab.avab.service.RecreationService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +21,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequestMapping("/api/recreations")
 @RequiredArgsConstructor
@@ -41,7 +44,7 @@ public class RecreationController {
     })
     @GetMapping("/{recreationId}")
     public BaseResponse<DescriptionDTO> getRecreationDescription(
-            @PathVariable(name = "recreationId") Long recreationId) {
+            @ExistRecreations @PathVariable(name = "recreationId") Long recreationId) {
         Recreation recreation = recreationService.getRecreationDescription(recreationId);
         return BaseResponse.onSuccess(RecreationConverter.toDescriptionDTO(recreation));
     }

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -37,7 +37,7 @@ public class RecreationController {
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
-    @GetMapping("/{recreationId}/description")
+    @GetMapping("/{recreationId}")
     public BaseResponse<DescriptionDTO> getRecreationDescription(
             @PathVariable(name = "recreationId") Long recreationId) {
         return BaseResponse.onSuccess(recreationService.getRecreationDescription(recreationId));

--- a/src/main/java/com/avab/avab/converter/RecreationConverter.java
+++ b/src/main/java/com/avab/avab/converter/RecreationConverter.java
@@ -3,7 +3,13 @@ package com.avab.avab.converter;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.avab.avab.domain.*;
+import com.avab.avab.domain.Recreation;
+import com.avab.avab.domain.RecreationHashtag;
+import com.avab.avab.domain.RecreationKeyword;
+import com.avab.avab.domain.RecreationAge;
+import com.avab.avab.domain.RecreationPreparation;
+import com.avab.avab.domain.RecreationWay;
+import com.avab.avab.domain.RecreationGender;
 import com.avab.avab.domain.enums.Age;
 import com.avab.avab.domain.enums.Gender;
 import com.avab.avab.domain.enums.Keyword;

--- a/src/main/java/com/avab/avab/converter/RecreationConverter.java
+++ b/src/main/java/com/avab/avab/converter/RecreationConverter.java
@@ -3,11 +3,12 @@ package com.avab.avab.converter;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.avab.avab.domain.Recreation;
-import com.avab.avab.domain.RecreationHashtag;
-import com.avab.avab.domain.RecreationKeyword;
+import com.avab.avab.domain.*;
+import com.avab.avab.domain.enums.Age;
+import com.avab.avab.domain.enums.Gender;
 import com.avab.avab.domain.enums.Keyword;
 import com.avab.avab.domain.mapping.RecreationRecreationKeyword;
+import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
 
 public class RecreationConverter {
@@ -32,6 +33,44 @@ public class RecreationConverter {
                 .title(recreation.getTitle())
                 .imageUrl(recreation.getImageUrl())
                 .totalStars(recreation.getTotal_stars())
+                .build();
+    }
+
+    public static DescriptionDTO toDescriptionDTO(Recreation recreation) {
+        List<String> hashtagList =
+                recreation.getRecreationHashTagsList().stream()
+                        .map(RecreationHashtag::getHashtag)
+                        .collect(Collectors.toList());
+
+        List<Age> ageList =
+                recreation.getRecreationAgeList().stream()
+                        .map(RecreationAge::getAge)
+                        .collect(Collectors.toList());
+
+        List<String> preparationList =
+                recreation.getRecreationPreparationList().stream()
+                        .map(RecreationPreparation::getName)
+                        .collect(Collectors.toList());
+
+        List<Gender> genderList =
+                recreation.getRecreationGenderList().stream()
+                        .map(RecreationGender::getGender)
+                        .collect(Collectors.toList());
+
+        List<String> wayList =
+                recreation.getRecreationWayList().stream()
+                        .map(RecreationWay::getContents)
+                        .collect(Collectors.toList());
+
+        return DescriptionDTO.builder()
+                .summary(recreation.getSummary())
+                .minParticipants(recreation.getMinParticipants())
+                .maxParticipants(recreation.getMaxParticipants())
+                .hashTagList(hashtagList)
+                .genderList(genderList)
+                .ageList(ageList)
+                .preparationList(preparationList)
+                .wayList(wayList)
                 .build();
     }
 }

--- a/src/main/java/com/avab/avab/converter/RecreationConverter.java
+++ b/src/main/java/com/avab/avab/converter/RecreationConverter.java
@@ -16,6 +16,7 @@ import com.avab.avab.domain.enums.Keyword;
 import com.avab.avab.domain.mapping.RecreationRecreationKeyword;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
+import com.avab.avab.dto.recreation.RecreationResponseDTO.WayDTO;
 
 public class RecreationConverter {
 
@@ -42,6 +43,13 @@ public class RecreationConverter {
                 .build();
     }
 
+    public static WayDTO toWayDTO(RecreationWay recreationWay) {
+        return WayDTO.builder()
+                .wayList(recreationWay.getContents())
+                .wayImgList(recreationWay.getImageUrl())
+                .build();
+    }
+
     public static DescriptionDTO toDescriptionDTO(Recreation recreation) {
         List<String> hashtagList =
                 recreation.getRecreationHashTagsList().stream()
@@ -63,14 +71,9 @@ public class RecreationConverter {
                         .map(RecreationGender::getGender)
                         .collect(Collectors.toList());
 
-        List<String> wayList =
+        List<WayDTO> wayList =
                 recreation.getRecreationWayList().stream()
-                        .map(RecreationWay::getContents)
-                        .collect(Collectors.toList());
-
-        List<String> wayImgList =
-                recreation.getRecreationWayList().stream()
-                        .map(RecreationWay::getImageUrl)
+                        .map(RecreationConverter::toWayDTO)
                         .collect(Collectors.toList());
 
         return DescriptionDTO.builder()
@@ -83,7 +86,6 @@ public class RecreationConverter {
                 .ageList(ageList)
                 .preparationList(preparationList)
                 .wayList(wayList)
-                .wayImgList(wayImgList)
                 .build();
     }
 }

--- a/src/main/java/com/avab/avab/converter/RecreationConverter.java
+++ b/src/main/java/com/avab/avab/converter/RecreationConverter.java
@@ -45,8 +45,8 @@ public class RecreationConverter {
 
     public static WayDTO toWayDTO(RecreationWay recreationWay) {
         return WayDTO.builder()
-                .wayList(recreationWay.getContents())
-                .wayImgList(recreationWay.getImageUrl())
+                .contents(recreationWay.getContents())
+                .imageUrl(recreationWay.getImageUrl())
                 .build();
     }
 

--- a/src/main/java/com/avab/avab/converter/RecreationConverter.java
+++ b/src/main/java/com/avab/avab/converter/RecreationConverter.java
@@ -68,7 +68,13 @@ public class RecreationConverter {
                         .map(RecreationWay::getContents)
                         .collect(Collectors.toList());
 
+        List<String> wayImgList =
+                recreation.getRecreationWayList().stream()
+                        .map(RecreationWay::getImageUrl)
+                        .collect(Collectors.toList());
+
         return DescriptionDTO.builder()
+                .recreationId(recreation.getId())
                 .summary(recreation.getSummary())
                 .minParticipants(recreation.getMinParticipants())
                 .maxParticipants(recreation.getMaxParticipants())
@@ -77,6 +83,7 @@ public class RecreationConverter {
                 .ageList(ageList)
                 .preparationList(preparationList)
                 .wayList(wayList)
+                .wayImgList(wayImgList)
                 .build();
     }
 }

--- a/src/main/java/com/avab/avab/dto/recreation/RecreationResponseDTO.java
+++ b/src/main/java/com/avab/avab/dto/recreation/RecreationResponseDTO.java
@@ -40,10 +40,18 @@ public class RecreationResponseDTO {
         List<String> hashTagList;
         List<Age> ageList;
         List<String> preparationList;
-        List<String> wayList;
-        List<String> wayImgList;
+        List<WayDTO> wayList;
         List<Gender> genderList;
         Integer minParticipants;
         Integer maxParticipants;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WayDTO {
+        String wayList;
+        String wayImgList;
     }
 }

--- a/src/main/java/com/avab/avab/dto/recreation/RecreationResponseDTO.java
+++ b/src/main/java/com/avab/avab/dto/recreation/RecreationResponseDTO.java
@@ -35,11 +35,13 @@ public class RecreationResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DescriptionDTO {
+        Long recreationId;
         String summary;
         List<String> hashTagList;
         List<Age> ageList;
         List<String> preparationList;
         List<String> wayList;
+        List<String> wayImgList;
         List<Gender> genderList;
         Integer minParticipants;
         Integer maxParticipants;

--- a/src/main/java/com/avab/avab/dto/recreation/RecreationResponseDTO.java
+++ b/src/main/java/com/avab/avab/dto/recreation/RecreationResponseDTO.java
@@ -51,7 +51,7 @@ public class RecreationResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class WayDTO {
-        String wayList;
-        String wayImgList;
+        String contents;
+        String imageUrl;
     }
 }

--- a/src/main/java/com/avab/avab/dto/recreation/RecreationResponseDTO.java
+++ b/src/main/java/com/avab/avab/dto/recreation/RecreationResponseDTO.java
@@ -2,6 +2,8 @@ package com.avab.avab.dto.recreation;
 
 import java.util.List;
 
+import com.avab.avab.domain.enums.Age;
+import com.avab.avab.domain.enums.Gender;
 import com.avab.avab.domain.enums.Keyword;
 
 import lombok.AllArgsConstructor;
@@ -26,5 +28,20 @@ public class RecreationResponseDTO {
         String imageUrl;
 
         Float totalStars;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DescriptionDTO {
+        String summary;
+        List<String> hashTagList;
+        List<Age> ageList;
+        List<String> preparationList;
+        List<String> wayList;
+        List<Gender> genderList;
+        Integer minParticipants;
+        Integer maxParticipants;
     }
 }

--- a/src/main/java/com/avab/avab/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/avab/avab/security/filter/JwtRequestFilter.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.filter;
+package com.avab.avab.security.filter;
 
 import java.io.IOException;
 
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
-import com.avab.avab.apiPayload.exception.auth.AuthException;
-import com.avab.avab.auth.jwt.JwtTokenProvider;
-import com.avab.avab.auth.principal.PrincipalDetailsService;
+import com.avab.avab.apiPayload.exception.AuthException;
+import com.avab.avab.security.principal.PrincipalDetailsService;
+import com.avab.avab.security.provider.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;
 
@@ -49,7 +49,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext()
                             .setAuthentication(usernamePasswordAuthenticationToken);
                 } else {
-                    throw new AuthException(ErrorStatus.AUTH_USER_NOT_FOUND);
+                    throw new AuthException(ErrorStatus.USER_NOT_FOUND);
                 }
             } else {
                 throw new AuthException(ErrorStatus.AUTH_INVALID_TOKEN);

--- a/src/main/java/com/avab/avab/security/handler/annotation/AuthUser.java
+++ b/src/main/java/com/avab/avab/security/handler/annotation/AuthUser.java
@@ -1,0 +1,10 @@
+package com.avab.avab.security.handler.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface AuthUser {}

--- a/src/main/java/com/avab/avab/security/handler/annotation/ExistRecreations.java
+++ b/src/main/java/com/avab/avab/security/handler/annotation/ExistRecreations.java
@@ -1,0 +1,24 @@
+package com.avab.avab.security.handler.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import com.avab.avab.security.handler.validator.ExistRecreationValidator;
+
+@Documented
+@Constraint(validatedBy = ExistRecreationValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistRecreations {
+    String message() default "존재하지 않는 레크레이션입니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/avab/avab/security/handler/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/avab/avab/security/handler/resolver/AuthUserArgumentResolver.java
@@ -35,7 +35,6 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory)
             throws Exception {
-        System.out.println("hihi");
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         Object principal = null;

--- a/src/main/java/com/avab/avab/security/handler/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/avab/avab/security/handler/resolver/AuthUserArgumentResolver.java
@@ -1,0 +1,59 @@
+package com.avab.avab.security.handler.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.avab.avab.apiPayload.code.status.ErrorStatus;
+import com.avab.avab.apiPayload.exception.GeneralException;
+import com.avab.avab.domain.User;
+import com.avab.avab.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory)
+            throws Exception {
+        System.out.println("hihi");
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Object principal = null;
+        if (authentication != null) {
+            // 로그인하지 않은 익명 사용자라면 null 반환
+            if (authentication.getName().equals("anonymousUser")) {
+                return null;
+            }
+            principal = authentication.getPrincipal();
+        }
+        if (principal == null || principal.getClass() == String.class) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                (UsernamePasswordAuthenticationToken) authentication;
+        Long userId = Long.valueOf(authenticationToken.getName());
+
+        return userService.findUserById(userId);
+    }
+}

--- a/src/main/java/com/avab/avab/security/handler/validator/ExistRecreationValidator.java
+++ b/src/main/java/com/avab/avab/security/handler/validator/ExistRecreationValidator.java
@@ -1,0 +1,35 @@
+package com.avab.avab.security.handler.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.springframework.stereotype.Component;
+
+import com.avab.avab.apiPayload.code.status.ErrorStatus;
+import com.avab.avab.repository.RecreationRepository;
+import com.avab.avab.security.handler.annotation.ExistRecreations;
+
+import lombok.AllArgsConstructor;
+
+@Component
+@AllArgsConstructor
+public class ExistRecreationValidator implements ConstraintValidator<ExistRecreations, Long> {
+    private final RecreationRepository recreationRepository;
+
+    @Override
+    public void initialize(ExistRecreations constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = recreationRepository.existsById(value);
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(
+                            ErrorStatus.RECREATION_NOT_FOUND.toString())
+                    .addConstraintViolation();
+        }
+        return isValid;
+    }
+}

--- a/src/main/java/com/avab/avab/security/principal/PrincipalDetails.java
+++ b/src/main/java/com/avab/avab/security/principal/PrincipalDetails.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.principal;
+package com.avab.avab.security.principal;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,7 +33,7 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getUsername();
+        return user.getId().toString();
     }
 
     public String getEmail() {

--- a/src/main/java/com/avab/avab/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/avab/avab/security/principal/PrincipalDetailsService.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.principal;
+package com.avab.avab.security.principal;
 
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
-import com.avab.avab.apiPayload.exception.auth.AuthException;
+import com.avab.avab.apiPayload.exception.AuthException;
 import com.avab.avab.domain.User;
 import com.avab.avab.repository.UserRepository;
 
@@ -25,7 +25,7 @@ public class PrincipalDetailsService implements UserDetailsService {
         User user =
                 userRepository
                         .findById(Long.parseLong(userId))
-                        .orElseThrow(() -> new AuthException(ErrorStatus.AUTH_USER_NOT_FOUND));
+                        .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND));
 
         return new PrincipalDetails(user);
     }

--- a/src/main/java/com/avab/avab/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/avab/avab/security/provider/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.jwt;
+package com.avab.avab.security.provider;
 
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
@@ -10,9 +10,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
-import com.avab.avab.apiPayload.exception.auth.AuthException;
+import com.avab.avab.apiPayload.exception.AuthException;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 
 @Component

--- a/src/main/java/com/avab/avab/security/test/AuthController.java
+++ b/src/main/java/com/avab/avab/security/test/AuthController.java
@@ -1,10 +1,13 @@
-package com.avab.avab.auth.test;
+package com.avab.avab.security.test;
 
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.avab.avab.apiPayload.BaseResponse;
-import com.avab.avab.auth.test.dto.LoginRequest;
-import com.avab.avab.auth.test.dto.LoginResponse;
+import com.avab.avab.security.test.dto.LoginRequest;
+import com.avab.avab.security.test.dto.LoginResponse;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/avab/avab/security/test/AuthService.java
+++ b/src/main/java/com/avab/avab/security/test/AuthService.java
@@ -1,12 +1,12 @@
-package com.avab.avab.auth.test;
+package com.avab.avab.security.test;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.avab.avab.auth.jwt.JwtTokenProvider;
-import com.avab.avab.auth.test.dto.LoginResponse;
 import com.avab.avab.domain.User;
 import com.avab.avab.repository.UserRepository;
+import com.avab.avab.security.provider.JwtTokenProvider;
+import com.avab.avab.security.test.dto.LoginResponse;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/avab/avab/security/test/dto/LoginRequest.java
+++ b/src/main/java/com/avab/avab/security/test/dto/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.test.dto;
+package com.avab.avab.security.test.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/avab/avab/security/test/dto/LoginResponse.java
+++ b/src/main/java/com/avab/avab/security/test/dto/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.avab.avab.auth.test.dto;
+package com.avab.avab.security.test.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/avab/avab/service/RecreationService.java
+++ b/src/main/java/com/avab/avab/service/RecreationService.java
@@ -2,8 +2,11 @@ package com.avab.avab.service;
 
 import java.util.List;
 
+import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
 
 public interface RecreationService {
     List<PopularRecreationListDTO> getTop3RecreationsByViewCount();
+
+    DescriptionDTO getRecreationDescription(Long recreationId);
 }

--- a/src/main/java/com/avab/avab/service/RecreationService.java
+++ b/src/main/java/com/avab/avab/service/RecreationService.java
@@ -2,11 +2,11 @@ package com.avab.avab.service;
 
 import java.util.List;
 
-import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
+import com.avab.avab.domain.Recreation;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
 
 public interface RecreationService {
     List<PopularRecreationListDTO> getTop3RecreationsByViewCount();
 
-    DescriptionDTO getRecreationDescription(Long recreationId);
+    Recreation getRecreationDescription(Long recreationId);
 }

--- a/src/main/java/com/avab/avab/service/UserService.java
+++ b/src/main/java/com/avab/avab/service/UserService.java
@@ -1,0 +1,8 @@
+package com.avab.avab.service;
+
+import com.avab.avab.domain.User;
+
+public interface UserService {
+
+    User findUserById(Long userId);
+}

--- a/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import com.avab.avab.converter.RecreationConverter;
 import com.avab.avab.domain.Recreation;
+import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
 import com.avab.avab.repository.RecreationRepository;
 import com.avab.avab.service.RecreationService;
@@ -26,5 +27,10 @@ public class RecreationServiceImpl implements RecreationService {
         return topRecreations.stream()
                 .map(RecreationConverter::convertToDTO)
                 .collect(Collectors.toList());
+    }
+
+    public DescriptionDTO getRecreationDescription(Long recreationId) {
+        Recreation recreation = recreationRepository.findById(recreationId).get();
+        return RecreationConverter.toDescriptionDTO(recreation);
     }
 }

--- a/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 
 import com.avab.avab.converter.RecreationConverter;
 import com.avab.avab.domain.Recreation;
-import com.avab.avab.dto.recreation.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.recreation.RecreationResponseDTO.PopularRecreationListDTO;
 import com.avab.avab.repository.RecreationRepository;
 import com.avab.avab.service.RecreationService;
@@ -29,8 +28,8 @@ public class RecreationServiceImpl implements RecreationService {
                 .collect(Collectors.toList());
     }
 
-    public DescriptionDTO getRecreationDescription(Long recreationId) {
+    public Recreation getRecreationDescription(Long recreationId) {
         Recreation recreation = recreationRepository.findById(recreationId).get();
-        return RecreationConverter.toDescriptionDTO(recreation);
+        return recreation;
     }
 }

--- a/src/main/java/com/avab/avab/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/UserServiceImpl.java
@@ -1,0 +1,27 @@
+package com.avab.avab.service.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.avab.avab.apiPayload.code.status.ErrorStatus;
+import com.avab.avab.apiPayload.exception.UserException;
+import com.avab.avab.domain.User;
+import com.avab.avab.repository.UserRepository;
+import com.avab.avab.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public User findUserById(Long userId) {
+        return userRepository
+                .findById(userId)
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/avab/avab/validation/annotation/ExistRecreation.java
+++ b/src/main/java/com/avab/avab/validation/annotation/ExistRecreation.java
@@ -1,4 +1,4 @@
-package com.avab.avab.security.handler.annotation;
+package com.avab.avab.validation.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -9,13 +9,13 @@ import java.lang.annotation.Target;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
-import com.avab.avab.security.handler.validator.ExistRecreationValidator;
+import com.avab.avab.validation.validator.ExistRecreationValidator;
 
 @Documented
 @Constraint(validatedBy = ExistRecreationValidator.class)
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ExistRecreations {
+public @interface ExistRecreation {
     String message() default "존재하지 않는 레크레이션입니다.";
 
     Class<?>[] groups() default {};

--- a/src/main/java/com/avab/avab/validation/validator/ExistRecreationValidator.java
+++ b/src/main/java/com/avab/avab/validation/validator/ExistRecreationValidator.java
@@ -1,4 +1,4 @@
-package com.avab.avab.security.handler.validator;
+package com.avab.avab.validation.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -7,17 +7,17 @@ import org.springframework.stereotype.Component;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
 import com.avab.avab.repository.RecreationRepository;
-import com.avab.avab.security.handler.annotation.ExistRecreations;
+import com.avab.avab.validation.annotation.ExistRecreation;
 
 import lombok.AllArgsConstructor;
 
 @Component
 @AllArgsConstructor
-public class ExistRecreationValidator implements ConstraintValidator<ExistRecreations, Long> {
+public class ExistRecreationValidator implements ConstraintValidator<ExistRecreation, Long> {
     private final RecreationRepository recreationRepository;
 
     @Override
-    public void initialize(ExistRecreations constraintAnnotation) {
+    public void initialize(ExistRecreation constraintAnnotation) {
         ConstraintValidator.super.initialize(constraintAnnotation);
     }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #15

## 📌 개요
- 레크레이션 상세설명 API 구현

## 🔁 변경 사항
- RecreationController, RecreationService(Impl), RecreationRepository, RecreationResponseDTO, RecreationConverter에 추가,
SecurityConfig에 상세설명 endpoint추가
- 레크레이션 존재 검증 어노테이션 (ExistRecreations) 구현
 : 3ecbad1acca93d4e64262d84381deb934a6158e4  -> 여기 확인해주시면 됩니다 ! 
 : ConstraintValidator 사용해서 validator 패키지 안에 만들어 뒀습니다. @ Validated 붙여서 사용하시면 될 것 같습니다. 혹시 수정해야할사항이 있다면 알려주세요!!!!

- 원래 커밋이 저렇게 한번에 많이 올라가나요?? 골라서 올려야하는거 제가 다 올린건가요 ,,,,,,,,,,,


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- [x] 예외처리(레크레이션 아이디 존재여부 확인 등)를 하나도 하지 않았는데 추가해야 할까요?
- [x] api구성을 **description/{recreationId}** 로 처리해뒀는데 **{recreationId}/description** 가 훨씬 괜찮다고 생각합니다! 근데  SecurityConfig에 endpoint를   **/api/recreations/*/description** 이렇게 적어서 테스트해봤더니 에러가 떠서 일단은 **description/{recreationId}** api설정해뒀습니다!  -> **{recreationId}/description** 이렇게 설정할 경우 endpoint를 어떻게 적어야할까요,,, 

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
