### PR TITLE
✨ [Feat]: 조회수 누적 및 반영 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/src/main/java/com/avab/avab/batch/RecreationViewCountItemReader.java
+++ b/src/main/java/com/avab/avab/batch/RecreationViewCountItemReader.java
@@ -1,0 +1,46 @@
+package com.avab.avab.batch;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.batch.item.ItemReader;
+import org.springframework.stereotype.Component;
+
+import com.avab.avab.domain.Recreation;
+import com.avab.avab.redis.service.RecreationViewCountService;
+import com.avab.avab.repository.RecreationRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RecreationViewCountItemReader implements ItemReader<Recreation> {
+
+    private final RecreationViewCountService recreationViewCountService;
+    private final RecreationRepository recreationRepository;
+    private List<Recreation> items;
+
+    @Override
+    public Recreation read() {
+        if (items == null) {
+            items =
+                    new ArrayList<>(
+                            recreationViewCountService.getAllRecreationIds().stream()
+                                    .map(recreationRepository::findById)
+                                    .filter(Optional::isPresent)
+                                    .map(Optional::get)
+                                    .toList());
+
+            log.info("조회수 업데이트 대상 레크레이션 ID: {}", items.stream().map(Recreation::getId).toList());
+        }
+
+        if (!items.isEmpty()) {
+            return items.remove(0);
+        }
+        items = null;
+        return null;
+    }
+}

--- a/src/main/java/com/avab/avab/batch/SchedulerConfig.java
+++ b/src/main/java/com/avab/avab/batch/SchedulerConfig.java
@@ -1,0 +1,42 @@
+package com.avab.avab.batch;
+
+import java.time.LocalDateTime;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+@Slf4j
+public class SchedulerConfig {
+
+    private final JobLauncher jobLauncher;
+    private final Job updateRecreationViewCountJob;
+
+    // 매 30분 마다 수행
+    @Scheduled(cron = "0 */30 * * * *")
+    public void updateRecreationViewCount()
+            throws JobInstanceAlreadyCompleteException,
+                    JobExecutionAlreadyRunningException,
+                    JobParametersInvalidException,
+                    JobRestartException {
+        JobParameters jobParameters =
+                new JobParametersBuilder()
+                        .addLocalDateTime("TIMESTAMP", LocalDateTime.now())
+                        .toJobParameters();
+        jobLauncher.run(updateRecreationViewCountJob, jobParameters);
+    }
+}

--- a/src/main/java/com/avab/avab/batch/UpdateRecreationViewCountConfig.java
+++ b/src/main/java/com/avab/avab/batch/UpdateRecreationViewCountConfig.java
@@ -1,0 +1,61 @@
+package com.avab.avab.batch;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.avab.avab.domain.Recreation;
+import com.avab.avab.redis.service.RecreationViewCountService;
+import com.avab.avab.repository.RecreationRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class UpdateRecreationViewCountConfig {
+
+    private final RecreationRepository recreationRepository;
+    private final RecreationViewCountService recreationViewCountService;
+    private final ItemReader<Recreation> itemReader;
+
+    @Bean
+    public Job updateRecreationViewCountJob(
+            JobRepository jobRepository, Step updateRecreationViewCountFirstStep) {
+        return new JobBuilder("Update Recreation View Count Job", jobRepository)
+                .start(updateRecreationViewCountFirstStep)
+                .build();
+    }
+
+    @Bean
+    public Step updateRecreationViewCountFirstStep(
+            JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("First Step", jobRepository)
+                .<Recreation, Recreation>chunk(100, transactionManager)
+                .reader(itemReader)
+                .processor(itemProcessor())
+                .writer(items -> {})
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<Recreation, Recreation> itemProcessor() {
+        return recreation -> {
+            Long viewCount = recreationViewCountService.getViewCount(recreation.getId());
+
+            if (viewCount != null) {
+                recreationRepository.incrementViewCountById(recreation.getId(), viewCount);
+            }
+
+            return recreation;
+        };
+    }
+}

--- a/src/main/java/com/avab/avab/config/RedisConfig.java
+++ b/src/main/java/com/avab/avab/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.avab.avab.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public LettuceConnectionFactory connectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public StringRedisTemplate redisTemplate() {
+        StringRedisTemplate redisTemplate = new StringRedisTemplate();
+
+        redisTemplate.setConnectionFactory(connectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -1,5 +1,18 @@
 package com.avab.avab.controller;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.avab.avab.apiPayload.BaseResponse;
 import com.avab.avab.converter.RecreationConverter;
 import com.avab.avab.domain.Recreation;
@@ -16,23 +29,13 @@ import com.avab.avab.security.handler.annotation.AuthUser;
 import com.avab.avab.service.RecreationService;
 import com.avab.avab.validation.annotation.ExistRecreation;
 import com.avab.avab.validation.annotation.ValidatePage;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/recreations")
@@ -43,7 +46,9 @@ public class RecreationController {
 
     private final RecreationService recreationService;
 
-    @Operation(summary = "인기 레크레이션 목록 조회 API", description = "조회수를 기준으로 인기 레크레이션 목록을 조회합니다. _by 루아_")
+    @Operation(
+            summary = "인기 레크레이션 목록 조회 API",
+            description = "조회수를 기준으로 인기 레크레이션 목록을 조회합니다. _by 루아_")
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
@@ -58,7 +63,7 @@ public class RecreationController {
     })
     @GetMapping("/{recreationId}")
     public BaseResponse<DescriptionDTO> getRecreationDescription(
-        @ExistRecreation @PathVariable(name = "recreationId") Long recreationId) {
+            @ExistRecreation @PathVariable(name = "recreationId") Long recreationId) {
         Recreation recreation = recreationService.getRecreationDescription(recreationId);
         return BaseResponse.onSuccess(RecreationConverter.toDescriptionDTO(recreation));
     }
@@ -68,42 +73,42 @@ public class RecreationController {
     @Parameter(name = "user", hidden = true)
     @GetMapping("/search")
     public BaseResponse<RecreationPreviewListDTO> searchRecreations(
-        @AuthUser User user,
-        @RequestParam(name = "searchKeyword", required = false) String searchKeyword,
-        @RequestParam(name = "keyword", required = false) List<Keyword> keywords,
-        @RequestParam(name = "participants", required = false) Integer participants,
-        @RequestParam(name = "playTime", required = false) Integer playTime,
-        @RequestParam(name = "place", required = false) List<Place> places,
-        @RequestParam(name = "gender", required = false) List<Gender> genders,
-        @RequestParam(name = "age", required = false) List<Age> ages,
-        @RequestParam(name = "page", required = false, defaultValue = "0") @ValidatePage
-        Integer page) {
+            @AuthUser User user,
+            @RequestParam(name = "searchKeyword", required = false) String searchKeyword,
+            @RequestParam(name = "keyword", required = false) List<Keyword> keywords,
+            @RequestParam(name = "participants", required = false) Integer participants,
+            @RequestParam(name = "playTime", required = false) Integer playTime,
+            @RequestParam(name = "place", required = false) List<Place> places,
+            @RequestParam(name = "gender", required = false) List<Gender> genders,
+            @RequestParam(name = "age", required = false) List<Age> ages,
+            @RequestParam(name = "page", required = false, defaultValue = "0") @ValidatePage
+                    Integer page) {
         Page<Recreation> recreationPage =
-            recreationService.searchRecreations(
-                user,
-                searchKeyword,
-                keywords,
-                participants,
-                playTime,
-                places,
-                genders,
-                ages,
-                page);
+                recreationService.searchRecreations(
+                        user,
+                        searchKeyword,
+                        keywords,
+                        participants,
+                        playTime,
+                        places,
+                        genders,
+                        ages,
+                        page);
 
         return BaseResponse.onSuccess(
-            RecreationConverter.toRecreationPreviewListDTO(recreationPage, user));
+                RecreationConverter.toRecreationPreviewListDTO(recreationPage, user));
     }
 
     @Operation(
-        summary = "레크레이션 즐겨찾기 추가/취소 API",
-        description = "레크레이션 즐겨찾기 안 했다면 즐겨찾기 추가, 했다면 즐겨찾기 취소합니다. _by 보노_")
+            summary = "레크레이션 즐겨찾기 추가/취소 API",
+            description = "레크레이션 즐겨찾기 안 했다면 즐겨찾기 추가, 했다면 즐겨찾기 취소합니다. _by 보노_")
     @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
     @Parameter(name = "user", hidden = true)
     @PostMapping("/{recreationId}/favorites")
     @ResponseStatus(code = HttpStatus.CREATED)
     public BaseResponse<FavoriteDTO> toggleFavoriteRecreation(
-        @PathVariable(name = "recreationId") @ExistRecreation Long recreationId,
-        @AuthUser User user) {
+            @PathVariable(name = "recreationId") @ExistRecreation Long recreationId,
+            @AuthUser User user) {
         Boolean isFavorite = recreationService.toggleFavoriteRecreation(recreationId, user);
 
         return BaseResponse.onSuccess(RecreationConverter.toFavoriteDTO(isFavorite));

--- a/src/main/java/com/avab/avab/converter/RecreationConverter.java
+++ b/src/main/java/com/avab/avab/converter/RecreationConverter.java
@@ -132,6 +132,7 @@ public class RecreationConverter {
                 .ageList(ageList)
                 .preparationList(preparationList)
                 .wayList(wayList)
+                .viewCount(recreation.getViewCount())
                 .build();
     }
 

--- a/src/main/java/com/avab/avab/dto/response/RecreationResponseDTO.java
+++ b/src/main/java/com/avab/avab/dto/response/RecreationResponseDTO.java
@@ -73,6 +73,7 @@ public class RecreationResponseDTO {
         List<Gender> genderList;
         Integer minParticipants;
         Integer maxParticipants;
+        Long viewCount;
     }
 
     @Builder

--- a/src/main/java/com/avab/avab/redis/repository/RecreationViewCountRepository.java
+++ b/src/main/java/com/avab/avab/redis/repository/RecreationViewCountRepository.java
@@ -1,0 +1,14 @@
+package com.avab.avab.redis.repository;
+
+import java.util.List;
+
+public interface RecreationViewCountRepository {
+
+    void incrementViewCount(String key);
+
+    void createViewCount(String key);
+
+    String getViewCount(String key);
+
+    List<String> getAllRecreationIds();
+}

--- a/src/main/java/com/avab/avab/redis/repository/RecreationViewCountRepositoryImpl.java
+++ b/src/main/java/com/avab/avab/redis/repository/RecreationViewCountRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.avab.avab.redis.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class RecreationViewCountRepositoryImpl implements RecreationViewCountRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private final String PREFIX = "recreationViewCount";
+
+    @Override
+    public void incrementViewCount(String key) {
+        redisTemplate.opsForValue().increment(PREFIX + ":" + key);
+    }
+
+    @Override
+    public void createViewCount(String key) {
+        redisTemplate.opsForValue().set(PREFIX + ":" + key, "0", 30, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public String getViewCount(String key) {
+        return redisTemplate.opsForValue().get(PREFIX + ":" + key);
+    }
+
+    @Override
+    public List<String> getAllRecreationIds() {
+        ScanOptions scanOptions =
+                ScanOptions.scanOptions().match(PREFIX + ":" + "*").count(100).build();
+        Cursor<String> cursor = redisTemplate.scan(scanOptions);
+
+        List<String> keys = new ArrayList<>();
+        while (cursor.hasNext()) {
+            keys.add(cursor.next());
+        }
+
+        return keys.stream().map(key -> key.split(":")[1]).toList();
+    }
+}

--- a/src/main/java/com/avab/avab/redis/service/RecreationViewCountService.java
+++ b/src/main/java/com/avab/avab/redis/service/RecreationViewCountService.java
@@ -1,0 +1,12 @@
+package com.avab.avab.redis.service;
+
+import java.util.List;
+
+public interface RecreationViewCountService {
+
+    void incrementViewCount(Long recreationId);
+
+    Long getViewCount(Long recreationId);
+
+    List<Long> getAllRecreationIds();
+}

--- a/src/main/java/com/avab/avab/redis/service/impl/RecreationViewCountServiceImpl.java
+++ b/src/main/java/com/avab/avab/redis/service/impl/RecreationViewCountServiceImpl.java
@@ -1,0 +1,47 @@
+package com.avab.avab.redis.service.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.avab.avab.redis.repository.RecreationViewCountRepository;
+import com.avab.avab.redis.service.RecreationViewCountService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecreationViewCountServiceImpl implements RecreationViewCountService {
+
+    private final RecreationViewCountRepository recreationViewCountRepository;
+
+    @Override
+    @Transactional
+    public void incrementViewCount(Long id) {
+        String recreationId = id.toString();
+
+        if (recreationViewCountRepository.getViewCount(recreationId) == null) {
+            recreationViewCountRepository.createViewCount(recreationId);
+        }
+
+        recreationViewCountRepository.incrementViewCount(recreationId);
+    }
+
+    @Override
+    public Long getViewCount(Long id) {
+        String recreationId = id.toString();
+
+        String viewCount = recreationViewCountRepository.getViewCount(recreationId);
+
+        return viewCount != null ? Long.valueOf(viewCount) : null;
+    }
+
+    @Override
+    public List<Long> getAllRecreationIds() {
+        return recreationViewCountRepository.getAllRecreationIds().stream()
+                .map(Long::valueOf)
+                .toList();
+    }
+}

--- a/src/main/java/com/avab/avab/repository/RecreationRepository.java
+++ b/src/main/java/com/avab/avab/repository/RecreationRepository.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.avab.avab.domain.Recreation;
 
@@ -13,4 +15,8 @@ public interface RecreationRepository
 
     @Query("SELECT r FROM Recreation r ORDER BY r.viewCount DESC")
     List<Recreation> findTop3ByOrderByViewCountDesc(Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Recreation r SET r.viewCount = r.viewCount + :viewCount WHERE r.id = :id")
+    void incrementViewCountById(@Param("id") Long id, @Param("viewCount") Long viewCount);
 }

--- a/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
 import com.avab.avab.apiPayload.exception.RecreationException;
@@ -19,6 +20,7 @@ import com.avab.avab.domain.enums.Keyword;
 import com.avab.avab.domain.enums.Place;
 import com.avab.avab.domain.mapping.RecreationFavorite;
 import com.avab.avab.dto.response.RecreationResponseDTO.PopularRecreationListDTO;
+import com.avab.avab.redis.service.RecreationViewCountService;
 import com.avab.avab.repository.RecreationFavoriteRepository;
 import com.avab.avab.repository.RecreationRepository;
 import com.avab.avab.service.RecreationService;
@@ -31,6 +33,7 @@ public class RecreationServiceImpl implements RecreationService {
 
     private final RecreationRepository recreationRepository;
     private final RecreationFavoriteRepository recreationFavoriteRepository;
+    private final RecreationViewCountService recreationViewCountService;
     private final Integer SEARCH_PAGE_SIZE = 9;
 
     public List<PopularRecreationListDTO> getTop3RecreationsByViewCount() {
@@ -41,8 +44,12 @@ public class RecreationServiceImpl implements RecreationService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
     public Recreation getRecreationDescription(Long recreationId) {
         Recreation recreation = recreationRepository.findById(recreationId).get();
+
+        recreationViewCountService.incrementViewCount(recreation.getId());
+
         return recreation;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 ## Default profile
 spring:
   application:
-    name: avab-dev
+    name: AvAb
   profiles:
     active: dev
 springdoc:
@@ -36,6 +36,9 @@ spring:
     redis:
       host: localhost
       port: 6379
+  batch:
+    jdbc:
+      initialize-schema: always
 # S3
 cloud:
   aws:
@@ -84,6 +87,9 @@ spring:
     redis:
       host: ${REDIS_URL}
       port: 6379
+  batch:
+    jdbc:
+      initialize-schema: always
 # S3
 cloud:
   aws:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #32 

## 📌 개요
- RedisTemplate
- 조회수 증가 로직
- 조회수 반영 로직

## 🔁 변경 사항
### RedisTemplate
87b4eb1e455bfeebdee82fe66337fedb861b4fc4
RedisRepository를 이용하면 동시성 제어가 안돼서 RedisTemplate을 이용했습니다!

### 조회수 증가 로직
723ae52c69a9bc156900b0cc2702a0ef78883eeb
1. 사용자가 레크레이션 조회한다. (레크레이션 상세 API를 호출한다)
2. Redis에 해당 레크레이션의 id를 가진 key가 있는지 확인한다.
   - 없다면 유효 기간을 30분으로 설정해서 새로 저장한다.
   - 있다면 해당 key의 조회수를 1 증가시킨다.

### 조회수 반영 로직
723ae52c69a9bc156900b0cc2702a0ef78883eeb
1. 매 30분마다 Scheduler와 Batch를 통해 누적된 조회수가 DB에 반영된다.
    - Redis에 저장된 recreationId를 모두 가져온다.
    - 실제로 업데이트 되는 레크레이션은 DB에 존재해야 한다. (레크레이션이 삭제된 경우까지 고려)
    - Redis에 누적된 조회수를 DB에 반영한다.
2.  Redis에 저장된 값들은 30분이 지나면 사라진다!
**📣 Batch 때문에 DB에 테이블들이 추가되는데 정상적인 테이블들이니 그냥 냅두시면 됩니다!**

## 📸 스크린샷
### 성능 비교
1. DB에 바로 조회수 1씩 증가
![스크린샷 2024-01-22 20 18 28](https://github.com/TeamAvAb/AvAb-Back/assets/52905679/7506d61f-cbe2-48de-848f-aed80e656949)
**Throughput: 1342.3/sec**

2. Redis에 조회수 누적
![스크린샷 2024-01-22 20 17 49](https://github.com/TeamAvAb/AvAb-Back/assets/52905679/5b324e52-4c22-4a2b-8054-2049ba780119)
**Throughput: 1629.5/sec**

약 20% 성능 향상
## 👀 기타 더 이야기해볼 점
아직 조회수 중복 방지는 추가하지 않았는데...
어떤 방식이 좋을지 고민하고 있습니다.
현재로서는 쿠키가 가장 나아보이는 것 같기도 하고.. 흠...
로그인 여부에 따라서도 바뀌어야 할 것 같기도 하고...
일단 중복 방지 기능은 차차 구현해보겠습니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
