### PR TITLE
♻️  [Refactor] 인기 레크레이션 조회 API 수정

### DIFF
--- a/src/main/generated/com/avab/avab/domain/QRecreation.java
+++ b/src/main/generated/com/avab/avab/domain/QRecreation.java
@@ -72,6 +72,8 @@ public class QRecreation extends EntityPathBase<Recreation> {
 
     public final NumberPath<Long> viewCount = createNumber("viewCount", Long.class);
 
+    public final NumberPath<Long> weeklyViewCount = createNumber("weeklyViewCount", Long.class);
+
     public QRecreation(String variable) {
         this(Recreation.class, forVariable(variable), INITS);
     }

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -59,12 +59,14 @@ public class RecreationController {
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
+    @Parameter(name = "user", hidden = true)
     @GetMapping("/popular")
-    public BaseResponse<RecreationPreviewListDTO> getTop9RecreationsByWeeklyViewCount() {
+    public BaseResponse<RecreationPreviewListDTO> getTop9RecreationsByWeeklyViewCount(
+            @AuthUser User user) {
         Page<Recreation> topRecreations = recreationService.getTop9RecreationsByWeeklyViewCount();
 
         return BaseResponse.onSuccess(
-                RecreationConverter.toRecreationPreviewListDTO(topRecreations, null));
+                RecreationConverter.toRecreationPreviewListDTO(topRecreations, user));
     }
 
     @Operation(summary = "레크레이션 상세설명 조회 API", description = "레크레이션 상세설명을 조회합니다. _by 수기_")

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -29,7 +29,6 @@ import com.avab.avab.domain.enums.Place;
 import com.avab.avab.dto.reqeust.RecreationRequestDTO.PostRecreationReviewDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.FavoriteDTO;
-import com.avab.avab.dto.response.RecreationResponseDTO.PopularRecreationListDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.RecreationPreviewListDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.RecreationReviewCreatedDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.RecreationReviewPageDTO;
@@ -61,8 +60,11 @@ public class RecreationController {
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     @GetMapping("/popular")
-    public BaseResponse<List<PopularRecreationListDTO>> getTop3RecreationsByViewCount() {
-        return BaseResponse.onSuccess(recreationService.getTop3RecreationsByViewCount());
+    public BaseResponse<RecreationPreviewListDTO> getTop9RecreationsByWeeklyViewCount() {
+        Page<Recreation> topRecreations = recreationService.getTop9RecreationsByWeeklyViewCount();
+
+        return BaseResponse.onSuccess(
+                RecreationConverter.toRecreationPreviewListDTO(topRecreations, null));
     }
 
     @Operation(summary = "레크레이션 상세설명 조회 API", description = "레크레이션 상세설명을 조회합니다. _by 수기_")

--- a/src/main/java/com/avab/avab/converter/RecreationConverter.java
+++ b/src/main/java/com/avab/avab/converter/RecreationConverter.java
@@ -9,20 +9,16 @@ import com.avab.avab.domain.Recreation;
 import com.avab.avab.domain.RecreationAge;
 import com.avab.avab.domain.RecreationGender;
 import com.avab.avab.domain.RecreationHashtag;
-import com.avab.avab.domain.RecreationKeyword;
 import com.avab.avab.domain.RecreationPreparation;
 import com.avab.avab.domain.RecreationReview;
 import com.avab.avab.domain.RecreationWay;
 import com.avab.avab.domain.User;
 import com.avab.avab.domain.enums.Age;
 import com.avab.avab.domain.enums.Gender;
-import com.avab.avab.domain.enums.Keyword;
 import com.avab.avab.domain.mapping.RecreationFavorite;
-import com.avab.avab.domain.mapping.RecreationRecreationKeyword;
 import com.avab.avab.dto.reqeust.RecreationRequestDTO.PostRecreationReviewDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.DescriptionDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.FavoriteDTO;
-import com.avab.avab.dto.response.RecreationResponseDTO.PopularRecreationListDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.RecreationPreviewDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.RecreationPreviewListDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.RecreationReviewCreatedDTO;
@@ -32,29 +28,6 @@ import com.avab.avab.dto.response.RecreationResponseDTO.RecreationReviewPageDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.WayDTO;
 
 public class RecreationConverter {
-
-    public static PopularRecreationListDTO convertToDTO(Recreation recreation) {
-        // 키워드 리스트 추출 및 변환
-        List<Keyword> keywordList =
-                recreation.getRecreationRecreationKeywordList().stream()
-                        .map(RecreationRecreationKeyword::getKeyword)
-                        .map(RecreationKeyword::getKeyword)
-                        .collect(Collectors.toList());
-
-        // 해시태그 리스트 추출 및 변환
-        List<String> hashtagList =
-                recreation.getRecreationHashTagsList().stream()
-                        .map(RecreationHashtag::getHashtag)
-                        .collect(Collectors.toList());
-
-        return PopularRecreationListDTO.builder()
-                .keywordList(keywordList)
-                .hashtagList(hashtagList)
-                .title(recreation.getTitle())
-                .imageUrl(recreation.getImageUrl())
-                .totalStars(recreation.getTotalStars())
-                .build();
-    }
 
     public static RecreationPreviewListDTO toRecreationPreviewListDTO(
             Page<Recreation> recreationPage, User user) {

--- a/src/main/java/com/avab/avab/domain/FlowAge.java
+++ b/src/main/java/com/avab/avab/domain/FlowAge.java
@@ -31,7 +31,7 @@ public class FlowAge {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(20")
+    @Column(columnDefinition = "VARCHAR(20)")
     private Age age;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/avab/avab/domain/FlowGender.java
+++ b/src/main/java/com/avab/avab/domain/FlowGender.java
@@ -31,7 +31,7 @@ public class FlowGender {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(10")
+    @Column(columnDefinition = "VARCHAR(10)")
     private Gender gender;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/avab/avab/domain/Recreation.java
+++ b/src/main/java/com/avab/avab/domain/Recreation.java
@@ -56,6 +56,8 @@ public class Recreation extends BaseEntity {
 
     private Long viewCount;
 
+    private Long weeklyViewCount;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id")
     private User author;

--- a/src/main/java/com/avab/avab/dto/response/RecreationResponseDTO.java
+++ b/src/main/java/com/avab/avab/dto/response/RecreationResponseDTO.java
@@ -20,23 +20,6 @@ public class RecreationResponseDTO {
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class PopularRecreationListDTO {
-
-        List<Keyword> keywordList;
-
-        List<String> hashtagList;
-
-        String title;
-
-        String imageUrl;
-
-        Float totalStars;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
     public static class RecreationPreviewDTO {
 
         Long id;

--- a/src/main/java/com/avab/avab/repository/RecreationRepository.java
+++ b/src/main/java/com/avab/avab/repository/RecreationRepository.java
@@ -1,7 +1,6 @@
 package com.avab.avab.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,8 +12,8 @@ import com.avab.avab.domain.Recreation;
 public interface RecreationRepository
         extends JpaRepository<Recreation, Long>, RecreationCustomRepository {
 
-    @Query("SELECT r FROM Recreation r ORDER BY r.viewCount DESC")
-    List<Recreation> findTop3ByOrderByViewCountDesc(Pageable pageable);
+    @Query("SELECT r FROM Recreation r ORDER BY r.weeklyViewCount DESC")
+    Page<Recreation> findTop9ByOrderByWeeklyViewCount(Pageable pageable);
 
     @Modifying
     @Query("UPDATE Recreation r SET r.viewCount = r.viewCount + :viewCount WHERE r.id = :id")

--- a/src/main/java/com/avab/avab/repository/RecreationRepository.java
+++ b/src/main/java/com/avab/avab/repository/RecreationRepository.java
@@ -12,8 +12,7 @@ import com.avab.avab.domain.Recreation;
 public interface RecreationRepository
         extends JpaRepository<Recreation, Long>, RecreationCustomRepository {
 
-    @Query("SELECT r FROM Recreation r ORDER BY r.weeklyViewCount DESC")
-    Page<Recreation> findTop9ByOrderByWeeklyViewCount(Pageable pageable);
+    Page<Recreation> findTop9ByOrderByWeeklyViewCountDesc(Pageable pageable);
 
     @Modifying
     @Query("UPDATE Recreation r SET r.viewCount = r.viewCount + :viewCount WHERE r.id = :id")

--- a/src/main/java/com/avab/avab/service/RecreationService.java
+++ b/src/main/java/com/avab/avab/service/RecreationService.java
@@ -12,11 +12,10 @@ import com.avab.avab.domain.enums.Gender;
 import com.avab.avab.domain.enums.Keyword;
 import com.avab.avab.domain.enums.Place;
 import com.avab.avab.dto.reqeust.RecreationRequestDTO.PostRecreationReviewDTO;
-import com.avab.avab.dto.response.RecreationResponseDTO.PopularRecreationListDTO;
 
 public interface RecreationService {
 
-    List<PopularRecreationListDTO> getTop3RecreationsByViewCount();
+    Page<Recreation> getTop9RecreationsByWeeklyViewCount();
 
     Page<Recreation> searchRecreations(
             User user,

--- a/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
@@ -2,7 +2,6 @@ package com.avab.avab.service.impl;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,7 +20,6 @@ import com.avab.avab.domain.enums.Keyword;
 import com.avab.avab.domain.enums.Place;
 import com.avab.avab.domain.mapping.RecreationFavorite;
 import com.avab.avab.dto.reqeust.RecreationRequestDTO.PostRecreationReviewDTO;
-import com.avab.avab.dto.response.RecreationResponseDTO.PopularRecreationListDTO;
 import com.avab.avab.redis.service.RecreationViewCountService;
 import com.avab.avab.repository.RecreationFavoriteRepository;
 import com.avab.avab.repository.RecreationRepository;
@@ -41,12 +39,8 @@ public class RecreationServiceImpl implements RecreationService {
     private final Integer SEARCH_PAGE_SIZE = 9;
     private final Integer REVIEW_PAGE_SIZE = 2;
 
-    public List<PopularRecreationListDTO> getTop3RecreationsByViewCount() {
-        List<Recreation> topRecreations =
-                recreationRepository.findTop3ByOrderByViewCountDesc(PageRequest.of(0, 3));
-        return topRecreations.stream()
-                .map(RecreationConverter::convertToDTO)
-                .collect(Collectors.toList());
+    public Page<Recreation> getTop9RecreationsByWeeklyViewCount() {
+        return recreationRepository.findTop9ByOrderByWeeklyViewCount(PageRequest.of(0, 9));
     }
 
     @Transactional

--- a/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
@@ -40,7 +40,7 @@ public class RecreationServiceImpl implements RecreationService {
     private final Integer REVIEW_PAGE_SIZE = 2;
 
     public Page<Recreation> getTop9RecreationsByWeeklyViewCount() {
-        return recreationRepository.findTop9ByOrderByWeeklyViewCount(PageRequest.of(0, 9));
+        return recreationRepository.findTop9ByOrderByWeeklyViewCountDesc(PageRequest.of(0, 9));
     }
 
     @Transactional


### PR DESCRIPTION

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #35 

## 📌 개요
- 인기 레크레이션을 이번주의 인기 레크레이션을 조회할 수 있게 변경
- 엔티티에 괄호가 없는 오타가 있어, 수정

## 🔁 변경 사항
- 엔티티에 칼럼 부분에 괄호가 빠진 부분을 수정하였습니다.
- 전체 viewCount를 기준으로 3개의 인기 레크레이션을 받아오는 것을 weeklyViewCount를 기준으로 9개를 받아올 수 있게 수정하였습니다.
- Recreation 엔티티에 weeklyViewCount를 추가하였습니다. Long입니다.
- 440bf0689534023e5b063b34586dba7a9c12e750

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
