### PR TITLE
✨ [Feat] 삭제, 신고된 게시글 마스킹 처리 - 레크레이션 인기/추천, 플로우 추천

### DIFF
--- a/src/main/java/com/avab/avab/controller/FlowController.java
+++ b/src/main/java/com/avab/avab/controller/FlowController.java
@@ -143,7 +143,7 @@ public class FlowController {
             @RequestParam(name = "age", required = false) List<Age> ages) {
         List<Flow> recommendFlows =
                 flowService.recommendFlows(
-                        keywords, participants, totalPlayTime, purposes, genders, ages);
+                        keywords, participants, totalPlayTime, purposes, genders, ages, user);
 
         return BaseResponse.onSuccess(FlowConverter.toFlowDetailListDTO(recommendFlows, user));
     }

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -245,7 +245,7 @@ public class RecreationController {
 
         List<Recreation> recommendRecreations =
                 recreationService.recommendRecreations(
-                        keywords, participants, playTime, purposes, genders, ages);
+                        keywords, participants, playTime, purposes, genders, ages, user);
 
         return BaseResponse.onSuccess(
                 RecreationConverter.toRecreationRecommendListDTO(recommendRecreations, user));

--- a/src/main/java/com/avab/avab/controller/RecreationController.java
+++ b/src/main/java/com/avab/avab/controller/RecreationController.java
@@ -76,7 +76,8 @@ public class RecreationController {
     @GetMapping("/popular")
     public BaseResponse<RecreationPreviewPageDTO> getTop9RecreationsByWeeklyViewCount(
             @AuthUser User user) {
-        Page<Recreation> topRecreations = recreationService.getTop9RecreationsByWeeklyViewCount();
+        Page<Recreation> topRecreations =
+                recreationService.getTop9RecreationsByWeeklyViewCount(user);
 
         return BaseResponse.onSuccess(
                 RecreationConverter.toRecreationPreviewPageDTO(topRecreations, user));

--- a/src/main/java/com/avab/avab/repository/FlowCustomRepository.java
+++ b/src/main/java/com/avab/avab/repository/FlowCustomRepository.java
@@ -3,6 +3,7 @@ package com.avab.avab.repository;
 import java.util.List;
 
 import com.avab.avab.domain.Flow;
+import com.avab.avab.domain.User;
 import com.avab.avab.domain.enums.Age;
 import com.avab.avab.domain.enums.Gender;
 import com.avab.avab.domain.enums.Keyword;
@@ -15,5 +16,6 @@ public interface FlowCustomRepository {
             Integer playTime,
             List<Purpose> purposes,
             List<Gender> genders,
-            List<Age> ages);
+            List<Age> ages,
+            User user);
 }

--- a/src/main/java/com/avab/avab/repository/MaskingPredicates.java
+++ b/src/main/java/com/avab/avab/repository/MaskingPredicates.java
@@ -1,0 +1,45 @@
+package com.avab.avab.repository;
+
+import static com.avab.avab.domain.QFlow.flow;
+import static com.avab.avab.domain.QRecreation.recreation;
+import static com.avab.avab.domain.QReport.report;
+
+import com.avab.avab.apiPayload.code.status.ErrorStatus;
+import com.avab.avab.apiPayload.exception.RecreationException;
+import com.avab.avab.domain.User;
+import com.avab.avab.domain.enums.ReportType;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+
+class MaskingPredicates {
+
+    static BooleanExpression notSoftDeletedFlow() {
+        return flow.deletedAt.isNull();
+    }
+
+    static BooleanExpression notSoftDeletedRecreation() {
+        return recreation.deletedAt.isNull();
+    }
+
+    static BooleanExpression notReportedFlowByUser(User user) {
+        if (user == null) {
+            return null;
+        }
+
+        return flow.id.notIn(
+                JPAExpressions.select(report.targetFlow.id)
+                        .from(report)
+                        .where(report.reportType.eq(ReportType.FLOW), report.reporter.eq(user)));
+    }
+
+    static BooleanExpression notReportedRecreationByUser(User user) {
+        if (user == null) throw new RecreationException(ErrorStatus.USER_NOT_FOUND);
+
+        return recreation.id.notIn(
+                JPAExpressions.select(report.targetRecreation.id)
+                        .from(report)
+                        .where(
+                                report.reportType.eq(ReportType.RECREATION),
+                                report.reporter.eq(user)));
+    }
+}

--- a/src/main/java/com/avab/avab/repository/RecreationCustomRepository.java
+++ b/src/main/java/com/avab/avab/repository/RecreationCustomRepository.java
@@ -43,7 +43,8 @@ public interface RecreationCustomRepository {
             List<Gender> genders,
             List<Age> ages,
             Integer participants,
-            Integer playTime);
+            Integer playTime,
+            User user);
 
     void updateTotalStars(Long recreationId);
 }

--- a/src/main/java/com/avab/avab/repository/RecreationCustomRepository.java
+++ b/src/main/java/com/avab/avab/repository/RecreationCustomRepository.java
@@ -47,4 +47,6 @@ public interface RecreationCustomRepository {
             User user);
 
     void updateTotalStars(Long recreationId);
+
+    Page<Recreation> findTop9ByOrderByWeeklyViewCountDesc(Pageable page, User user);
 }

--- a/src/main/java/com/avab/avab/repository/RecreationCustomRepositoryImpl.java
+++ b/src/main/java/com/avab/avab/repository/RecreationCustomRepositoryImpl.java
@@ -429,4 +429,24 @@ public class RecreationCustomRepositoryImpl implements RecreationCustomRepositor
                 .where(recreation.id.eq(recreationId))
                 .execute();
     }
+
+    public Page<Recreation> findTop9ByOrderByWeeklyViewCountDesc(Pageable pageable, User user) {
+        long totalCount =
+                queryFactory
+                        .selectFrom(recreation)
+                        .where(notReportedRecreationByUser(user), notSoftDeletedRecreation())
+                        .fetch()
+                        .size();
+
+        List<Recreation> filteredRecreations =
+                queryFactory
+                        .selectFrom(recreation)
+                        .where(notReportedRecreationByUser(user), notSoftDeletedRecreation())
+                        .orderBy(recreation.weeklyViewCount.desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        return new PageImpl<>(filteredRecreations, pageable, totalCount);
+    }
 }

--- a/src/main/java/com/avab/avab/repository/RecreationRepository.java
+++ b/src/main/java/com/avab/avab/repository/RecreationRepository.java
@@ -12,8 +12,6 @@ import com.avab.avab.domain.Recreation;
 public interface RecreationRepository
         extends JpaRepository<Recreation, Long>, RecreationCustomRepository {
 
-    Page<Recreation> findTop9ByOrderByWeeklyViewCountDesc(Pageable pageable);
-
     Page<Recreation> findByOrderByCreatedAtDesc(Pageable pageable);
 
     @Modifying

--- a/src/main/java/com/avab/avab/service/FlowService.java
+++ b/src/main/java/com/avab/avab/service/FlowService.java
@@ -37,7 +37,8 @@ public interface FlowService {
             Integer totalPlayTime,
             List<Purpose> purposes,
             List<Gender> genders,
-            List<Age> ages);
+            List<Age> ages,
+            User user);
 
     Flow updateFlow(PostFlowDTO request, User user, Long flowId);
 

--- a/src/main/java/com/avab/avab/service/RecreationService.java
+++ b/src/main/java/com/avab/avab/service/RecreationService.java
@@ -59,7 +59,8 @@ public interface RecreationService {
             Integer playTime,
             List<Purpose> purposes,
             List<Gender> genders,
-            List<Age> ages);
+            List<Age> ages,
+            User user);
 
     Page<Recreation> getRecentRecreation(Integer page);
 

--- a/src/main/java/com/avab/avab/service/RecreationService.java
+++ b/src/main/java/com/avab/avab/service/RecreationService.java
@@ -20,7 +20,7 @@ import com.avab.avab.dto.reqeust.RecreationRequestDTO.PostRecreationReviewDTO;
 
 public interface RecreationService {
 
-    Page<Recreation> getTop9RecreationsByWeeklyViewCount();
+    Page<Recreation> getTop9RecreationsByWeeklyViewCount(User user);
 
     Page<Recreation> searchRecreations(
             User user,

--- a/src/main/java/com/avab/avab/service/impl/FlowServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/FlowServiceImpl.java
@@ -261,9 +261,10 @@ public class FlowServiceImpl implements FlowService {
             Integer totalPlayTime,
             List<Purpose> purposes,
             List<Gender> genders,
-            List<Age> ages) {
+            List<Age> ages,
+            User user) {
         return flowRepository.recommendFlows(
-                keywords, participants, totalPlayTime, purposes, genders, ages);
+                keywords, participants, totalPlayTime, purposes, genders, ages, user);
     }
 
     @Override

--- a/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
@@ -62,8 +62,9 @@ public class RecreationServiceImpl implements RecreationService {
     private final Integer SEARCH_PAGE_SIZE = 9;
     private final Integer REVIEW_PAGE_SIZE = 2;
 
-    public Page<Recreation> getTop9RecreationsByWeeklyViewCount() {
-        return recreationRepository.findTop9ByOrderByWeeklyViewCountDesc(PageRequest.of(0, 9));
+    public Page<Recreation> getTop9RecreationsByWeeklyViewCount(User user) {
+        return recreationRepository.findTop9ByOrderByWeeklyViewCountDesc(
+                PageRequest.of(0, 9), user);
     }
 
     @Transactional

--- a/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/RecreationServiceImpl.java
@@ -282,9 +282,10 @@ public class RecreationServiceImpl implements RecreationService {
             Integer playTime,
             List<Purpose> purposes,
             List<Gender> genders,
-            List<Age> ages) {
+            List<Age> ages,
+            User user) {
         return recreationRepository.recommendRecreations(
-                purposes, keywords, genders, ages, participants, playTime);
+                purposes, keywords, genders, ages, participants, playTime, user);
     }
 
     @Override


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #161

## 📌 개요
1. 
-  레크레이션 추천 마스킹 처리
- 인기 레크레이션 조회 마스킹 처리
- 플로우 추천 마스킹 처리 

2. 
82bbacf5131a2ce73c6f46c12adcc63b6b292f29
구현 과정에서 마스킹 처리하는 메스드 (notSoftDeletedFlow, notReportedFlowByUser) 가 중복되어서 따로 빼냈습니다.
기존 메서드가 private이여서 package-private으로 빼냈습니다.
다른 좋은 방법이 있다면 이야기 해보면 좋을 것 같습니다.

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
