### PR TITLE
✨ [Feat]: 탈퇴한 사용자 복구 API

### DIFF
--- a/src/main/java/com/avab/avab/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/avab/avab/apiPayload/code/status/ErrorStatus.java
@@ -36,7 +36,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // User 관련
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_004", "존재하지 않는 사용자입니다."),
-    USER_ALREADY_DELETE(HttpStatus.BAD_REQUEST, "USER_001", "이미 삭제된 사용자입니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER_001", "이미 삭제된 사용자입니다."),
+    USER_NOT_DELETED(HttpStatus.BAD_REQUEST, "USER_002", "삭제되지 않은 사용자입니다."),
 
     // Recreation 관련
     SEARCH_CONDITION_INVALID(HttpStatus.BAD_REQUEST, "RECR_001", "검색 조건이 하나라도 존재해야 합니다."),

--- a/src/main/java/com/avab/avab/controller/AuthController.java
+++ b/src/main/java/com/avab/avab/controller/AuthController.java
@@ -46,8 +46,8 @@ public class AuthController {
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     @PostMapping("/refresh")
-    @Parameter(name = "refreshToken", hidden = true)
-    public BaseResponse<TokenRefreshResponse> refresh(@ExtractToken String refreshToken) {
+    public BaseResponse<TokenRefreshResponse> refresh(
+            @Parameter(hidden = true) @ExtractToken String refreshToken) {
         return BaseResponse.onSuccess(authService.refresh(refreshToken));
     }
 

--- a/src/main/java/com/avab/avab/controller/UserController.java
+++ b/src/main/java/com/avab/avab/controller/UserController.java
@@ -23,7 +23,9 @@ import com.avab.avab.dto.response.FlowResponseDTO.FlowPreviewPageDTO;
 import com.avab.avab.dto.response.RecreationResponseDTO.RecreationPreviewPageDTO;
 import com.avab.avab.dto.response.UserResponseDTO;
 import com.avab.avab.dto.response.UserResponseDTO.UserResponse;
+import com.avab.avab.dto.response.UserResponseDTO.UserRestoreDeletionResponse;
 import com.avab.avab.security.handler.annotation.AuthUser;
+import com.avab.avab.security.handler.annotation.ExtractToken;
 import com.avab.avab.service.UserService;
 import com.avab.avab.validation.annotation.ValidatePage;
 
@@ -111,5 +113,15 @@ public class UserController {
     public BaseResponse<UserResponseDTO.UserResponse> deleteUser(@AuthUser User user) {
         User deletedUser = userService.deleteUser(user);
         return BaseResponse.onSuccess(UserConverter.toUserResponse(deletedUser));
+    }
+
+    @Operation(summary = "회원 탈퇴 복구", description = "탈퇴한 회원의 계정을 복구합니다. _by 보노_")
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
+    @Parameter(name = "user", hidden = true)
+    @PatchMapping("/me/deleted")
+    public BaseResponse<UserRestoreDeletionResponse> restoreUser(
+            @ExtractToken String restoreToken) {
+        User restoredUser = userService.restoreUserDeletion(restoreToken);
+        return BaseResponse.onSuccess(UserConverter.toUserRestoreDeletionResponse(restoredUser));
     }
 }

--- a/src/main/java/com/avab/avab/converter/AuthConverter.java
+++ b/src/main/java/com/avab/avab/converter/AuthConverter.java
@@ -23,6 +23,7 @@ public class AuthConverter {
                 .refreshToken(refreshToken)
                 .accessToken(accessToken)
                 .isLogin(isLogin)
+                .isDeleted(user.isDeleted())
                 .userId(user.getId())
                 .build();
     }

--- a/src/main/java/com/avab/avab/converter/UserConverter.java
+++ b/src/main/java/com/avab/avab/converter/UserConverter.java
@@ -15,4 +15,12 @@ public class UserConverter {
                 .profileImage(user.getProfileImage())
                 .build();
     }
+
+    public static UserResponseDTO.UserRestoreDeletionResponse toUserRestoreDeletionResponse(
+            User user) {
+        return UserResponseDTO.UserRestoreDeletionResponse.builder()
+                .userId(user.getId())
+                .isRestored(user.isEnabled())
+                .build();
+    }
 }

--- a/src/main/java/com/avab/avab/domain/User.java
+++ b/src/main/java/com/avab/avab/domain/User.java
@@ -133,4 +133,8 @@ public class User extends BaseEntity {
     public Boolean isFlowScrapped(Flow flow) {
         return this.flowScrapList.stream().anyMatch(it -> it.isTargetFlow(flow));
     }
+
+    public Boolean isEnabled() {
+        return this.userStatus == UserStatus.ENABLED;
+    }
 }

--- a/src/main/java/com/avab/avab/dto/response/AuthResponseDTO.java
+++ b/src/main/java/com/avab/avab/dto/response/AuthResponseDTO.java
@@ -18,6 +18,7 @@ public class AuthResponseDTO {
         String accessToken;
         String refreshToken;
         Boolean isLogin;
+        Boolean isDeleted;
     }
 
     @Getter

--- a/src/main/java/com/avab/avab/dto/response/UserResponseDTO.java
+++ b/src/main/java/com/avab/avab/dto/response/UserResponseDTO.java
@@ -28,4 +28,15 @@ public class UserResponseDTO {
 
         private String profileImage;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class UserRestoreDeletionResponse {
+
+        private Long userId;
+
+        private Boolean isRestored;
+    }
 }

--- a/src/main/java/com/avab/avab/security/test/TestAuthService.java
+++ b/src/main/java/com/avab/avab/security/test/TestAuthService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
 import com.avab.avab.apiPayload.exception.AuthException;
-import com.avab.avab.apiPayload.exception.UserException;
 import com.avab.avab.converter.AuthConverter;
 import com.avab.avab.domain.User;
 import com.avab.avab.domain.enums.SocialType;
@@ -60,7 +59,8 @@ public class TestAuthService {
         if (queryUser.isPresent()) {
             User user = queryUser.get();
             if (user.isDeleted()) {
-                throw new UserException(ErrorStatus.USER_NOT_FOUND);
+                return AuthConverter.toOAuthResponse(
+                        jwtTokenProvider.createRestoreToken(user.getId()), null, true, user);
             }
             if (user.isDisabled()) {
                 if (user.isCanBeEnabled()) {

--- a/src/main/java/com/avab/avab/service/UserService.java
+++ b/src/main/java/com/avab/avab/service/UserService.java
@@ -24,4 +24,6 @@ public interface UserService {
     User deleteUser(User user);
 
     void hardDeleteOldUser(LocalDate threshold);
+
+    User restoreUserDeletion(String restoreToken);
 }

--- a/src/main/java/com/avab/avab/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/AuthServiceImpl.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.avab.avab.apiPayload.code.status.ErrorStatus;
 import com.avab.avab.apiPayload.exception.AuthException;
-import com.avab.avab.apiPayload.exception.UserException;
 import com.avab.avab.converter.AuthConverter;
 import com.avab.avab.domain.User;
 import com.avab.avab.domain.enums.SocialType;
@@ -50,7 +49,8 @@ public class AuthServiceImpl implements AuthService {
         if (queryUser.isPresent()) {
             User user = queryUser.get();
             if (user.isDeleted()) {
-                throw new UserException(ErrorStatus.USER_NOT_FOUND);
+                return AuthConverter.toOAuthResponse(
+                        jwtTokenProvider.createRestoreToken(user.getId()), null, true, user);
             }
             if (user.isDisabled()) {
                 if (user.isCanBeEnabled()) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,6 +132,7 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-validity: ${JWT_ACCESS_TOKEN_TIME}
   refresh-token-validity: ${JWT_REFRESH_TOKEN_TIME}
+  restore-token-validity: ${JWT_RESTORE_TOKEN_TIME}
 #kakao
 kakao:
   auth:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #191 

## 📌 개요
- 탈퇴한 사용자 로그인 시 탈퇴 여부 및 복구 토큰 발급
- 탈퇴한 사용자 복구 API

## 🔁 변경 사항
### 탈퇴 여부 및 복구 토큰 발급
로그인 시 응답에 `isDeleted` 필드 추가
탈퇴한 회원인 경우 `accessToken`에 복구 토큰 발급
복구 토큰은 claim에 restore 필드값이 true로 설정되어 있고 토큰 유효 기간은 매우 짧게 설정 (5분으로 생각 중, 환경변수 추가해야함)

### 탈퇴한 사용자 복구 API
복구 토큰으로 사용자 특정하여 복구 처리

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x]  PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
