### PR TITLE
🐛 [Bug] Flow 생성 시 participants 기본 값 설정 및 Flow 생성/업데이트 중복 코드 제거

### DIFF
--- a/src/main/java/com/avab/avab/dto/reqeust/FlowRequestDTO.java
+++ b/src/main/java/com/avab/avab/dto/reqeust/FlowRequestDTO.java
@@ -24,7 +24,7 @@ public class FlowRequestDTO {
         String title;
         List<RecreationSpec> recreationSpecList;
         Integer totalPlayTime;
-        Integer participants;
+        Integer participants = 0;
         List<Age> ageList;
         List<Purpose> purposeList;
         List<Keyword> keywordList;

--- a/src/main/java/com/avab/avab/service/impl/FlowServiceImpl.java
+++ b/src/main/java/com/avab/avab/service/impl/FlowServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 
+import org.jetbrains.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -143,10 +144,7 @@ public class FlowServiceImpl implements FlowService {
     @Override
     @Transactional
     public Boolean toggleScrapeFlow(User user, Long flowId) {
-        Flow flow =
-                flowRepository
-                        .findById(flowId)
-                        .orElseThrow(() -> new FlowException(ErrorStatus.FLOW_NOT_FOUND));
+        Flow flow = getFlow(flowId);
         Optional<FlowScrap> flowFavorite = flowScrapRepository.findByFlowAndUser(flow, user);
 
         if (flowFavorite.isPresent()) {
@@ -165,77 +163,27 @@ public class FlowServiceImpl implements FlowService {
 
     @Transactional
     public Flow postFlow(PostFlowDTO request, User user) {
-        Map<Integer, Recreation> recreationMap = new HashMap<>();
-        Map<Integer, CustomRecreation> customRecreationMap = new HashMap<>();
-
-        request.getRecreationSpecList()
-                .forEach(
-                        spec -> {
-                            if (spec.getRecreationId() != null) {
-                                Recreation recreation =
-                                        recreationRepository
-                                                .findById(spec.getRecreationId())
-                                                .orElseThrow(
-                                                        () ->
-                                                                new RecreationException(
-                                                                        ErrorStatus
-                                                                                .RECREATION_NOT_FOUND));
-                                recreationMap.put(spec.getSeq(), recreation);
-                            } else {
-                                List<RecreationKeyword> customRecreationKeywordList =
-                                        new ArrayList<>();
-                                if (spec.getCustomKeywordList() != null) {
-                                    customRecreationKeywordList =
-                                            spec.getCustomKeywordList().stream()
-                                                    .map(
-                                                            keyword ->
-                                                                    recreationKeywordRepository
-                                                                            .findByKeyword(keyword)
-                                                                            .get())
-                                                    .toList();
-                                }
-
-                                CustomRecreation customRecreation =
-                                        FlowConverter.toCustomRecreation(
-                                                spec, customRecreationKeywordList);
-
-                                customRecreationRepository.save(customRecreation);
-                                customRecreationMap.put(spec.getSeq(), customRecreation);
-                            }
-                        });
+        Map<Integer, Recreation> recreationMap = extractRecreationMap(request);
+        Map<Integer, CustomRecreation> customRecreationMap = extractCustomRecreationMap(request);
 
         List<RecreationKeyword> recreationKeywordList =
-                request.getKeywordList().stream()
-                        .map(keyword -> recreationKeywordRepository.findByKeyword(keyword).get())
-                        .toList();
-
+                getRecreationKeywords(request.getKeywordList());
         List<RecreationPurpose> recreationPurposeList =
-                request.getPurposeList().stream()
-                        .map(purpose -> recreationPurposeRepository.findByPurpose(purpose).get())
-                        .toList();
+                getRecreationPurposes(request.getPurposeList());
 
-        int num = flowNumber.nextInt(4);
-        Flow flow =
-                FlowConverter.toFlow(
-                        request,
-                        user,
-                        flowImageUrl[num],
-                        recreationMap,
-                        customRecreationMap,
-                        recreationKeywordList,
-                        recreationPurposeList);
-
-        flowRepository.save(flow);
-
-        return flow;
+        return createOrUpdateFlow(
+                request,
+                user,
+                recreationMap,
+                customRecreationMap,
+                recreationKeywordList,
+                recreationPurposeList,
+                null);
     }
 
     @Transactional
     public void deleteFlow(Long flowId, User user) {
-        Flow flow =
-                flowRepository
-                        .findById(flowId)
-                        .orElseThrow(() -> new FlowException(ErrorStatus.FLOW_NOT_FOUND));
+        Flow flow = getFlow(flowId);
         if (!flow.isAuthoredBy(user)) {
             throw new FlowException(ErrorStatus.FLOW_DELETE_UNAUTHORIZED);
         }
@@ -259,10 +207,7 @@ public class FlowServiceImpl implements FlowService {
     @Override
     @Transactional
     public Flow updateFlow(PostFlowDTO request, User user, Long flowId) {
-        Flow flow =
-                flowRepository
-                        .findById(flowId)
-                        .orElseThrow(() -> new FlowException(ErrorStatus.FLOW_NOT_FOUND));
+        Flow flow = getFlow(flowId);
 
         // custom, ageList, purposeList, genderList, keywordList는 시작하자마자 삭제 (일단 모두 삭제로 구현)
         flowRecreationKeywordRepository.deleteAllByFlow(flow);
@@ -271,73 +216,115 @@ public class FlowServiceImpl implements FlowService {
         flowAgeRepository.deleteAllByFlow(flow);
         flowRecreationRepository.deleteAllByFlow(flow);
 
-        Map<Integer, Recreation> recreationMap = new HashMap<>();
-        Map<Integer, CustomRecreation> customRecreationMap = new HashMap<>();
-
-        request.getRecreationSpecList()
-                .forEach(
-                        spec -> {
-                            if (spec.getRecreationId() != null) {
-                                Recreation recreation =
-                                        recreationRepository
-                                                .findById(spec.getRecreationId())
-                                                .orElseThrow(
-                                                        () ->
-                                                                new RecreationException(
-                                                                        ErrorStatus
-                                                                                .RECREATION_NOT_FOUND));
-                                recreationMap.put(spec.getSeq(), recreation);
-                            } else {
-                                List<RecreationKeyword> customRecreationKeywordList =
-                                        new ArrayList<>();
-                                if (spec.getCustomKeywordList() != null) {
-                                    customRecreationKeywordList =
-                                            spec.getCustomKeywordList().stream()
-                                                    .map(
-                                                            keyword ->
-                                                                    recreationKeywordRepository
-                                                                            .findByKeyword(keyword)
-                                                                            .get())
-                                                    .toList();
-                                }
-
-                                CustomRecreation customRecreation =
-                                        FlowConverter.toCustomRecreation(
-                                                spec, customRecreationKeywordList);
-
-                                customRecreationRepository.save(customRecreation);
-                                customRecreationMap.put(spec.getSeq(), customRecreation);
-                            }
-                        });
+        Map<Integer, Recreation> recreationMap = extractRecreationMap(request);
+        Map<Integer, CustomRecreation> customRecreationMap = extractCustomRecreationMap(request);
 
         List<RecreationKeyword> recreationKeywordList =
-                request.getKeywordList().stream()
-                        .map(keyword -> recreationKeywordRepository.findByKeyword(keyword).get())
-                        .toList();
-
+                getRecreationKeywords(request.getKeywordList());
         List<RecreationPurpose> recreationPurposeList =
-                request.getPurposeList().stream()
-                        .map(purpose -> recreationPurposeRepository.findByPurpose(purpose).get())
-                        .toList();
+                getRecreationPurposes(request.getPurposeList());
 
-        int num = flowNumber.nextInt(4);
-        Flow updateFlow =
-                FlowConverter.toUpdateFlow(
-                        flowId,
-                        request,
-                        user,
-                        flowImageUrl[num],
-                        recreationMap,
-                        customRecreationMap,
-                        recreationKeywordList,
-                        recreationPurposeList);
-
-        return flowRepository.save(updateFlow);
+        return createOrUpdateFlow(
+                request,
+                user,
+                recreationMap,
+                customRecreationMap,
+                recreationKeywordList,
+                recreationPurposeList,
+                flowId);
     }
 
     @Override
     @Transactional
     public void incrementViewCountLast7Days(Long flowId, Long viewCount) {
         flowRepository.updateViewCountLast7DaysById(flowId, viewCount);
+    }
+
+    private Map<Integer, Recreation> extractRecreationMap(PostFlowDTO request) {
+        Map<Integer, Recreation> recreationMap = new HashMap<>();
+
+        for (var spec : request.getRecreationSpecList()) {
+            if (spec.getRecreationId() != null) {
+                Recreation recreation = getRecreation(spec.getRecreationId());
+                recreationMap.put(spec.getSeq(), recreation);
+            }
+        }
+
+        return recreationMap;
+    }
+
+    private Map<Integer, CustomRecreation> extractCustomRecreationMap(PostFlowDTO request) {
+        Map<Integer, CustomRecreation> customRecreationMap = new HashMap<>();
+
+        for (var spec : request.getRecreationSpecList()) {
+            if (spec.getRecreationId() == null) {
+                List<RecreationKeyword> keywords = new ArrayList<>();
+                if (spec.getCustomKeywordList() != null) {
+                    keywords = getRecreationKeywords(spec.getCustomKeywordList());
+                }
+                CustomRecreation customRecreation =
+                        FlowConverter.toCustomRecreation(spec, keywords);
+                customRecreationRepository.save(customRecreation);
+                customRecreationMap.put(spec.getSeq(), customRecreation);
+            }
+        }
+        return customRecreationMap;
+    }
+
+    private Flow createOrUpdateFlow(
+            PostFlowDTO request,
+            User user,
+            Map<Integer, Recreation> recreationMap,
+            Map<Integer, CustomRecreation> customRecreationMap,
+            List<RecreationKeyword> recreationKeywordList,
+            List<RecreationPurpose> recreationPurposeList,
+            @Nullable Long flowId) {
+        int num = flowNumber.nextInt(4);
+
+        Flow flow =
+                (flowId == null)
+                        ? FlowConverter.toFlow(
+                                request,
+                                user,
+                                flowImageUrl[num],
+                                recreationMap,
+                                customRecreationMap,
+                                recreationKeywordList,
+                                recreationPurposeList)
+                        : FlowConverter.toUpdateFlow(
+                                flowId,
+                                request,
+                                user,
+                                flowImageUrl[num],
+                                recreationMap,
+                                customRecreationMap,
+                                recreationKeywordList,
+                                recreationPurposeList);
+
+        return flowRepository.save(flow);
+    }
+
+    private Flow getFlow(Long flowId) {
+        return flowRepository
+                .findById(flowId)
+                .orElseThrow(() -> new FlowException(ErrorStatus.FLOW_NOT_FOUND));
+    }
+
+    private Recreation getRecreation(Long recreationId) {
+        return recreationRepository
+                .findById(recreationId)
+                .orElseThrow(() -> new RecreationException(ErrorStatus.RECREATION_NOT_FOUND));
+    }
+
+    private List<RecreationKeyword> getRecreationKeywords(List<Keyword> keywords) {
+        return keywords.stream()
+                .map(keyword -> recreationKeywordRepository.findByKeyword(keyword).get())
+                .toList();
+    }
+
+    private List<RecreationPurpose> getRecreationPurposes(List<Purpose> purposes) {
+        return purposes.stream()
+                .map(purpose -> recreationPurposeRepository.findByPurpose(purpose).get())
+                .toList();
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #211

## 📌 개요
- 예외 로그 확인해보니 다음과 같았고, 플로우 추천 과정이 아닌 플로우 생성과정에서 `participants` 값을 지정해주지 않으면 null로 저장되어 추후 조회 로직에서 에러가 발생하는 것이었습니다. => 디폴트 값 0 으로 설정해두었습니다 5f372b414585292c6d83fbcfcbae98781e98cc26

**[예외 로그]**
```
{
  "isSuccess": false,
  "code": "COMMON500",
  "message": "서버 에러, 관리자에게 문의 바랍니다.",
  "result": "Cannot invoke \"java.lang.Integer.intValue()\" because the return value of \"com.avab.avab.domain.Flow.getParticipants()\" is null"
}
```

- 플로우 생성(`postFlow()`) 을 살펴보니 내부 로직이 길어 가독성이 떨어져, updateFlow()와 중복되는 부분을 별도의 private 메서드로 모듈화하였습니다. ed65950d3fca05a8c3abab6cb15e3b9c914d6946

- FlowConverter의 `toFlow()`와 `toUpdateFlow()`가 거의 동일한 로직을 포함하고 있어 중복 코드를 ` buildFlow() `메서드로 분리하였습니다. 이를 통해 생성과 업데이트 시 **ID 유무**에 따라 구분하여 사용할 수 있도록 개선했습니다. ac610b2e99045cc60309127f7b1806f196df6457


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
